### PR TITLE
Link macro names in code blocks (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.0] - 2026-08-10
+
+### Added
+ - Macro names in code blocks now link to their docstring, like function calls
+   and type annotations already did. ([#8], [#10])
+
+### Changed
+ - Reference links on qualified names (`Foo.bar(...)`, `Foo.@bar`,
+   `x::Foo.Bar`) now wrap only the name; the module qualifier and dot stay
+   outside the link. ([#10])
+
 ## [v1.1.0] - 2026-08-02
 
 ### Changed
@@ -48,6 +59,9 @@ See [README.md](README.md) and the documentation for details.
 [v1.0.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.0.0
 [v1.0.1]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.0.1
 [v1.1.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.1.0
+[v1.2.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.2.0
 [#3]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/3
 [#5]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/5
 [#6]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/6
+[#8]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/8
+[#10]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/10

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocumenterCodeBlocks"
 uuid = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Fredrik Ekre <ekrefredrik@gmail.com>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Enhanced code blocks for [Documenter.jl](https://github.com/JuliaDocs/Documenter
   URL.
 - **Reference links**: identifiers in code blocks that name a documented object link to its
   docstring — call-arity aware, so `foo(1, 2)` links to the `foo(a, b)` method
-  documentation.
+  documentation. Macro names link too.
 - **Hover tooltips** (doxygen style) on every reference link: the target's signature and a
   one-line summary, embedded at build time. Ambiguous references show the candidate-method
   list instead.

--- a/docs/demo.jl
+++ b/docs/demo.jl
@@ -252,3 +252,23 @@ Combine three things. The second docstring of the aggregated `combine` entry;
 its signature header must be stripped of gutter/links just like the first.
 """
 combine(a, b, c) = (a, b, c)
+
+"""
+    @twice(expr)
+
+Evaluate `expr` twice and return the value of the second evaluation. A
+documented **macro**: macro names in code blocks link to their docstring.
+"""
+macro twice(expr)
+    return esc(:($(expr); $(expr)))
+end
+
+"""
+    w"text"
+
+Return `text` unchanged. A documented **string macro**: the `w` prefix of a
+`w"…"` literal links to this docstring.
+"""
+macro w_str(s)
+    return s
+end

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,4 +38,6 @@ measure()
 combine
 process(data::AbstractMatrix, weights::AbstractVector)
 process(data::AbstractVector)
+@twice
+@w_str
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,8 @@ enhances Julia code blocks:
   a stable fragment like `#c-1a2b3c4d-L3-L7` in the URL.
 - **[Reference links](@ref references)**: identifiers in code blocks that name
   a documented object link to its docstring — call-arity aware, so
-  `foo(1, 2)` links to the `foo(a, b)` method documentation.
+  `foo(1, 2)` links to the `foo(a, b)` method documentation. Macro names
+  link too.
 - **[Hover tooltips](@ref tooltips)** on every reference link, doxygen style:
   the target's signature and a one-line summary, embedded at build time.
   Ambiguous references show the candidate-method list.

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -32,11 +32,23 @@ thing:
 a = foo(1)      # links the foo(a) docstring
 b = foo(1, 2)   # links the foo(a, b) docstring
 c = foo         # plain value mention → no link
+d = DocumenterCodeBlocks.foo(1)   # qualified call
 ```
 
 As the block above shows, resolution is **arity-aware**: a call with `n`
 positional arguments links to the method documented with `n` arguments,
-not just to the first documented method.
+not just to the first documented method. Qualified names resolve as a
+whole, but the link attaches to the name itself — the module qualifier
+and dot stay outside.
+
+**Macro calls** link on their name. No syntactic vouching is needed there:
+unlike a bare identifier, a macro name can only ever mean the macro.
+
+```julia
+@twice greet()                       # unqualified macro name
+DocumenterCodeBlocks.@twice greet()  # qualified name
+s = w"hello"                         # string macro
+```
 
 Code blocks inside docstrings get reference links too, with one exception:
 a reference that resolves back to the enclosing docstring itself is left

--- a/src/DocumenterCodeBlocks.jl
+++ b/src/DocumenterCodeBlocks.jl
@@ -18,7 +18,7 @@ blocks), so no node/`prerender` is needed.
 
 - `languages`: which code-block languages to process.
 - `reference_links`: wrap identifiers that name a documented object in a link to
-  its docstring.
+  its docstring. Macro names link too.
 - `popups`: doxygen-style hover tooltips on reference links, embedded per page
   (no fetching): the target's signature and the docstring's first sentence.
   When a reference matches several documented methods (a bare identifier, a

--- a/src/juliasyntax.jl
+++ b/src/juliasyntax.jl
@@ -5,9 +5,10 @@
 # tile the source exactly, so every byte is emitted by exactly one leaf. Context
 # that a leaf can't see on its own — "I'm the callee of a call" → funcall, "I'm to
 # the right of a `::`" → type — is passed *down* as an inherited `role`. Reference
-# links attach to whole nodes (an identifier leaf, or a dotted-name subtree) and
-# only in role-vouched positions (callees and type annotations); a node that
-# resolves wraps its emitted children in an <a>.
+# links resolve whole names (an identifier leaf, a dotted-name subtree, a macro
+# name) in role-vouched positions (callees and type annotations) and on macro
+# calls; the emitted <a> wraps just the name — for a qualified name the module
+# prefix and dot stay outside the link.
 #
 # Multiline string/comment tokens keep their embedded newlines; `split_highlighted`
 # then breaks the emitted HTML into per-line fragments (reopening spans/anchors).
@@ -121,6 +122,70 @@ function _is_dotted_name(node)
     return true
 end
 
+# The reference name spelled by a `.` node at the head of a `macrocall`, or
+# `nothing` when the node is not a qualified macro name. Written as-is for
+# `Foo.@bar` (and the legacy `@Foo.bar`, which parses to the same binding);
+# a qualified string/command literal gets the sigil and suffix its binding
+# carries: `Foo.bar"…"` → `Foo.@bar_str`.
+function _dotted_macro_name(cu, node, offset)
+    cs = _JS.children(node)
+    (cs === nothing || isempty(cs)) && return nothing
+    tail, tailoff, o = nothing, offset, offset
+    for c in cs
+        kc = _JS.kind(c)
+        (
+            kc == K"Identifier" || kc == K"." || kc == K"@" || kc == K"MacroName" ||
+                kc == K"StringMacroName" || kc == K"CmdMacroName" || _JS.is_trivia(c)
+        ) || return nothing
+        _JS.is_trivia(c) || ((tail, tailoff) = (c, o))
+        o += Int(_JS.span(c))
+    end
+    tail === nothing && return nothing
+    k = _JS.kind(tail)
+    k == K"MacroName" && return _text(cu, _noderange(offset, node))
+    (k == K"StringMacroName" || k == K"CmdMacroName") || return nothing
+    suffix = k == K"StringMacroName" ? "_str" : "_cmd"
+    # The dotted prefix as written ("Foo."), then sigil + name + suffix.
+    return string(
+        _text(cu, (offset + 1):tailoff), "@", _text(cu, _noderange(tailoff, tail)), suffix,
+    )
+end
+
+# The macro name at the head of a `macrocall` node: which of its children spell
+# the name, and the name to resolve the reference by. Four shapes occur:
+#
+#     @time x      → the `@` token plus a `MacroName` leaf   → "@time"
+#     Foo.@bar x   → a `.` node (see `_dotted_macro_name`)   → "Foo.@bar"
+#     raw"…"       → a `StringMacroName` leaf                → "@raw_str"
+#     x`…`         → a `CmdMacroName` leaf                   → "@x_cmd"
+#
+# Returns `(first, last, name)` — inclusive child indices plus the name — or
+# `nothing` when the node does not start with a macro name after all.
+function _macro_name(cu, node, offset)
+    o, i, start = offset, 0, 0
+    for c in _JS.children(node)
+        i += 1
+        kc = _JS.kind(c)
+        r = _noderange(o, c)
+        if start != 0
+            # After the `@` sigil (itself a trivia token) comes the name.
+            kc == K"MacroName" && return (first = start, last = i, name = "@" * _text(cu, r))
+            _JS.is_trivia(c) || return nothing
+        elseif kc == K"@"
+            start = i
+        elseif kc == K"." && (n = _dotted_macro_name(cu, c, o)) !== nothing
+            return (first = i, last = i, name = n)
+        elseif kc == K"StringMacroName" || kc == K"CmdMacroName"
+            suffix = kc == K"StringMacroName" ? "_str" : "_cmd"
+            return (first = i, last = i, name = string("@", _text(cu, r), suffix))
+        elseif !_JS.is_trivia(c)
+            return nothing
+        end
+        o += Int(_JS.span(c))
+    end
+    return nothing
+end
+
 # A quoted symbol (`:foo`): exactly the `:` token followed by an identifier.
 # (Excludes `quote … end` blocks and quoted expressions like `:(a + b)`.)
 function _is_symbol_quote(node)
@@ -155,10 +220,29 @@ end
 _is_arg(c) = !_JS.is_trivia(c) &&
     !(_JS.kind(c) in _PUNCT) && !(_JS.kind(c) in (K"parameters", K"="))
 
+# The (first, last) child indices a reference link wraps within a dotted node:
+# the last non-trivia child — the name — plus the `@` sigil right before it
+# when present, so `Foo.@bar` keeps the sigil in the link like a bare `@bar`
+# does. (In the legacy `@Foo.bar` spelling the sigil sits up front, detached
+# from the name; only the name is wrapped there.)
+function _name_span(node)
+    cs = _JS.children(node)
+    e = 0
+    for (i, c) in enumerate(cs)
+        _JS.is_trivia(c) || (e = i)
+    end
+    e == 0 && return nothing
+    s = (e > 1 && _JS.kind(cs[e - 1]) == K"@") ? e - 1 : e
+    return (s, e)
+end
+
 # The single recursive pass: emit `node` (at byte `offset`) under inherited `role`.
 # `arity` is the call argument count to pass to link resolution for a callee node
 # (or `nothing`), so a call links to the method with that many arguments.
-function _emit!(io, cu, node, offset, role, arity, in_link, resolve)
+# `pref` is a pre-resolved reference handed down by a `macrocall` parent whose
+# name is this (dotted) node — the link is opened here so it can wrap just the
+# name part instead of the whole qualified path.
+function _emit!(io, cu, node, offset, role, arity, in_link, resolve, pref = nothing)
     k = _JS.kind(node)
     r = _noderange(offset, node)
 
@@ -177,15 +261,27 @@ function _emit!(io, cu, node, offset, role, arity, in_link, resolve)
         return
     end
 
-    # Whole dotted name (Foo.bar) resolving as one link wraps its children.
-    linkhere = false
-    if linkable && !in_link && resolve !== nothing && k == K"." && _is_dotted_name(node)
-        ref = resolve(_text(cu, r), arity)
-        if ref !== nothing
-            _print_ref_open(io, ref)
-            linkhere = true
-        end
+    # A dotted name (Foo.bar) resolves as a whole, but the link wraps only the
+    # trailing name — the module qualifier and dot stay outside. `pref` is the
+    # already-resolved reference when a macrocall parent delegated its dotted
+    # name here.
+    dotref = pref
+    if dotref === nothing && linkable && !in_link && resolve !== nothing &&
+            k == K"." && _is_dotted_name(node)
+        dotref = resolve(_text(cu, r), arity)
     end
+    dotspan = dotref === nothing ? nothing : _name_span(node)
+
+    # A macro call links on its name (`@time`, `Foo.@bar`, the `raw` of
+    # `raw"…"`). No role gating is needed here: unlike a bare identifier, a
+    # macro name can only ever mean the macro. Only the name tokens are
+    # wrapped — the macro arguments are ordinary code, and a qualified name's
+    # module prefix stays outside the link (delegated to the `.` child via
+    # `pref`). Arity is not passed along: macro docstrings are bound without
+    # a signature (`Union{}`), so there is no per-arity method to pick.
+    macroname = (!in_link && resolve !== nothing && k == K"macrocall") ?
+        _macro_name(cu, node, offset) : nothing
+    macroref = macroname === nothing ? nothing : resolve(macroname.name, nothing)
 
     prefixcall = k in (K"call", K"dotcall") && _JS.is_prefix_call(node)
     # Splat arguments make the positional count a lower bound instead of exact:
@@ -234,11 +330,25 @@ function _emit!(io, cu, node, offset, role, arity, in_link, resolve)
             crole = (i == last_ident) ? role : :none      # only the last id carries the role
             carity = (i == last_ident) ? arity : nothing
         end
-        _emit!(io, cu, c, o, crole, carity, in_link || linkhere, resolve)
+        # The link wraps the children in `dotspan`/the macro-name span; the
+        # other children of a linked node are emitted `in_link` anyway so the
+        # name resolves once, as a whole (no stray link on a module prefix).
+        indot = dotspan !== nothing && dotspan[1] <= i <= dotspan[2]
+        (indot && i == dotspan[1]) && _print_ref_open(io, dotref)
+        inname = macroref !== nothing && macroname.first <= i <= macroname.last
+        # A dotted macro name delegates: the `.` child wraps its own name part.
+        cpref = (inname && kc == K".") ? macroref : nothing
+        wrapname = inname && cpref === nothing
+        (wrapname && i == macroname.first) && _print_ref_open(io, macroref)
+        _emit!(
+            io, cu, c, o, crole, carity,
+            in_link || wrapname || dotspan !== nothing, resolve, cpref,
+        )
+        (wrapname && i == macroname.last) && print(io, "</a>")
+        (indot && i == dotspan[2]) && print(io, "</a>")
         o += Int(_JS.span(c))
     end
 
-    linkhere && print(io, "</a>")
     return
 end
 

--- a/src/references.jl
+++ b/src/references.jl
@@ -46,13 +46,17 @@ function resolve_reference(name::AbstractString, doc, page, arity = nothing, plu
     page === nothing && return nothing
     mod = get(page.globals.meta, :CurrentModule, Main)
 
-    # Parse the identifier; accept a bare symbol or a dotted path (Foo.bar).
+    # Parse the identifier; accept a bare symbol, a dotted path (Foo.bar), or a
+    # macro name (`@time`, `Foo.@bar`, `@raw_str`) — the latter parses as a
+    # `:macrocall` whose first argument is the macro's name, a form
+    # `DocSystem.binding` already knows how to resolve.
     ex = try
         Meta.parse(name)
     catch
         return nothing
     end
-    (ex isa Symbol || (ex isa Expr && ex.head === :.)) || return nothing
+    (ex isa Symbol || (ex isa Expr && (ex.head === :. || ex.head === :macrocall))) ||
+        return nothing
 
     binding = try
         DocSystem.binding(mod, ex)

--- a/test/docsite/demo.jl
+++ b/test/docsite/demo.jl
@@ -316,3 +316,31 @@ every `fit` call site is ambiguous and both multiline headers appear as
 collapsed one-line labels in the candidate list.
 """
 fit(X::AbstractMatrix, w::AbstractVector) = nothing
+
+"""
+    @twice(expr)
+
+Evaluate `expr` twice and return the value of the second evaluation. A
+documented **macro**: macro names in code blocks link to their docstring,
+whether written unqualified or qualified.
+
+# Examples
+
+```julia
+@twice greet()                 # the macro itself: a self reference, not linked
+x = add_numbers(1, @twice 2)   # nested in a call: still linked
+```
+"""
+macro twice(expr)
+    return esc(:($(expr); $(expr)))
+end
+
+"""
+    w"text"
+
+Return `text` unchanged. A documented **string macro**: the `w` prefix of a
+`w"…"` literal links to this docstring.
+"""
+macro w_str(s)
+    return s
+end

--- a/test/docsite/src/index.md
+++ b/test/docsite/src/index.md
@@ -44,4 +44,6 @@ DocumenterCodeBlocks.fit(x::AbstractVector, y::AbstractVector)
 DocumenterCodeBlocks.fit(X::AbstractMatrix, w::AbstractVector)
 DocumenterCodeBlocks.process(data::AbstractMatrix, weights::AbstractVector)
 DocumenterCodeBlocks.process(data::AbstractVector)
+DocumenterCodeBlocks.@twice
+DocumenterCodeBlocks.@w_str
 ```

--- a/test/docsite/src/references.md
+++ b/test/docsite/src/references.md
@@ -25,6 +25,20 @@ end
 For comparison, the same names in markdown resolve with `@ref`:
 [`add_numbers`](@ref), [`greet`](@ref), and [`MyType`](@ref).
 
+## Macros
+
+Macro names link like call callees do, whether written unqualified, qualified,
+or as the prefix of a string-macro literal. An undocumented macro stays plain
+text.
+
+```julia
+@twice greet()                       # unqualified macro name
+DocumenterCodeBlocks.@twice greet()  # qualified name
+@twice(add_numbers(1, 2))            # arguments keep their own links
+s = w"hello"                         # string macro
+@undocumented_macro 1                # not documented → plain text
+```
+
 ## Multiple methods
 
 `foo` has two documented methods, [`foo(a)`](@ref) and [`foo(a, b)`](@ref), each
@@ -36,6 +50,7 @@ stays unlinked.
 a = foo(1)      # links the foo(a) docstring
 b = foo(1, 2)   # links the foo(a, b) docstring
 c = foo         # plain value mention → no link
+d = DocumenterCodeBlocks.foo(1)   # qualified call: the link is on the name only
 ```
 
 ## Hover popups

--- a/test/playwright/verify-popup.js
+++ b/test/playwright/verify-popup.js
@@ -49,13 +49,26 @@ function check(name, ok, extra) {
   check("ambiguous links carry data-ref-targets", nAmbig >= 2, `found ${nAmbig}`);
 
   // --- role gating: only callees and type positions link -------------------
-  // foo appears in 4 call positions; the plain value mentions (`c = foo`) must
-  // NOT produce links, so exactly 4 foo links exist on the page.
+  // foo appears in 5 call positions (one qualified); the plain value mentions
+  // (`c = foo`) must NOT produce links, so exactly 5 foo links exist.
   const nFoo = await page.locator('a.julia-ref[href*="foo-Tuple"]').count();
-  check("plain value mentions are not linked (4 foo call links)", nFoo === 4, `found ${nFoo}`);
+  check("plain value mentions are not linked (5 foo call links)", nFoo === 5, `found ${nFoo}`);
   // `m::MyType` annotation + `MyType(3)` callee both link.
   const nMyType = await page.locator('a.julia-ref[href$="MyType"]').count();
   check("type annotations link (2 MyType links)", nMyType >= 2, `found ${nMyType}`);
+  // Macro names link too — sigil included, the module qualifier of a
+  // qualified name excluded, and string-macro prefixes through their
+  // `@…_str` name.
+  const nTwice = await page.locator('a.julia-ref[href$="@twice"]').count();
+  check("macro names link (3 @twice links)", nTwice === 3, `found ${nTwice}`);
+  const twiceTexts = await page.locator('a.julia-ref[href$="@twice"]').allInnerTexts();
+  check(
+    "links wrap the name only (sigil in, qualifier out)",
+    twiceTexts.length === 3 && twiceTexts.every((t) => t === "@twice"),
+    JSON.stringify(twiceTexts)
+  );
+  const nWstr = await page.locator('a.julia-ref[href$="@w_str"]').count();
+  check("string-macro prefix links via @w_str", nWstr === 1, `found ${nWstr}`);
 
   const popup = page.locator(".ref-popup");
 
@@ -82,6 +95,15 @@ function check(name, ok, extra) {
       JSON.stringify(brief)
     );
     check("signature is syntax-highlighted", (await popup.locator(".ref-tip-sig .julia-funcall").count()) > 0);
+  }
+
+  // --- macro reference: tooltip like any other link -----------------------
+  const macroLink = page.locator('a.julia-ref[href$="@twice"]').first();
+  check("tooltip appears on macro hover", await hoverAndTip(macroLink));
+  {
+    const sig = await popup.locator(".ref-tip-sig").innerText().catch(() => "");
+    check("macro tooltip shows the signature", /@twice\(expr\)/.test(sig), JSON.stringify(sig));
+    check("macro name is highlighted", (await popup.locator(".ref-tip-sig .julia-macro").count()) > 0);
   }
 
   // --- docstring without a leading signature block → synthesized ----------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,13 +66,72 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
         @test !occursin("<span class=\"julia-funcall\">f</span> (generic", r2)
     end
 
+    @testset "macro names" begin
+        # A stub resolver records the names asked for and links every one, so
+        # the shapes of macro-name references can be checked without a build.
+        asked = String[]
+        function stub(name, arity)
+            push!(asked, name)
+            t = (href = "#$name", tipkey = "#$name", label = name, sig = name, brief = nothing)
+            return (href = t.href, targets = [t])
+        end
+        h(src) = DCB.highlight_julia_html(src; resolve = stub)
+        link(name) = "<a class=\"julia-ref\" href=\"#$name\">"
+        # The `@` sigil is part of the link, and the arguments are not.
+        @test h("@time f(x)") ==
+            link("@time") * "<span class=\"julia-macro\">@</span>" *
+            "<span class=\"julia-macro\">time</span></a> " *
+            link("f") * "<span class=\"julia-funcall\">f</span></a>(x)"
+        # Qualified names resolve as a whole but the link wraps only the name
+        # (sigil included); the module qualifier and dot stay outside.
+        @test startswith(
+            h("Foo.@bar x"),
+            "Foo<span class=\"julia-operator\">.</span>" * link("Foo.@bar") *
+                "<span class=\"julia-macro\">@</span><span class=\"julia-macro\">bar</span></a>",
+        )
+        # In the legacy `@Foo.bar` spelling the sigil is detached from the
+        # name, so only the name is wrapped.
+        @test startswith(
+            h("@Foo.bar x"),
+            "<span class=\"julia-macro\">@</span>Foo<span class=\"julia-operator\">.</span>" *
+                link("@Foo.bar") * "<span class=\"julia-macro\">bar</span></a>",
+        )
+        # String/cmd macros resolve through their `@…_str`/`@…_cmd` names; the
+        # literal itself is not part of the link.
+        @test startswith(h("raw\"hi\""), link("@raw_str") * "<span class=\"julia-macro\">raw</span></a>")
+        @test startswith(h("x`cmd`"), link("@x_cmd"))
+        # A qualified literal resolves under the name its binding carries.
+        @test startswith(
+            h("Foo.bar\"hi\""),
+            "Foo<span class=\"julia-operator\">.</span>" * link("Foo.@bar_str") *
+                "<span class=\"julia-macro\">bar</span></a>",
+        )
+        @test occursin(link("Foo.Sub.@bar_cmd") * "<span class=\"julia-macro\">bar</span></a>", h("Foo.Sub.bar`c`"))
+        # Qualified function calls and type annotations get the same
+        # treatment: resolve `Foo.bar`, link only `bar`.
+        @test h("Foo.bar(1)") ==
+            "Foo<span class=\"julia-operator\">.</span>" * link("Foo.bar") *
+            "<span class=\"julia-funcall\">bar</span></a>(<span class=\"julia-number\">1</span>)"
+        @test endswith(
+            h("x::Foo.Bar"),
+            "Foo<span class=\"julia-operator\">.</span>" * link("Foo.Bar") *
+                "<span class=\"julia-type\">Bar</span></a>",
+        )
+        empty!(asked)
+        h("@show(a, b)\n@__MODULE__\nf(@view A[1])\nx::@NamedTuple{a::Int}")
+        @test asked == ["@show", "@__MODULE__", "f", "@view", "@NamedTuple", "Int"]
+        # Nothing links without a resolver (docstring signature headers).
+        @test !occursin("julia-ref", DCB.highlight_julia_html("@time f(x)"))
+    end
+
     @testset "split_highlighted" begin
         @test DCB.split_highlighted("a\nb") == ["a", "b"]
         # A span crossing a newline is closed and reopened per line.
         @test DCB.split_highlighted("<span class=\"x\">a\nb</span>") ==
             ["<span class=\"x\">a</span>", "<span class=\"x\">b</span>"]
-        # Non-span tags close/reopen with their own tag name (a dotted-name
-        # reference link can legally cross a newline: `Foo.\n    bar`).
+        # Non-span tags close/reopen with their own tag name (reference links
+        # wrap only a name and rarely cross a newline, but the splitter must
+        # not depend on that).
         @test DCB.split_highlighted("<a href=\"#\">Foo.\nbar</a>") ==
             ["<a href=\"#\">Foo.</a>", "<a href=\"#\">bar</a>"]
         # Nested mixed tags close innermost-first.
@@ -153,12 +212,40 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
         ]
 
         @testset "role-gated reference links" begin
-            # foo appears in 4 call positions; plain value mentions must not link.
-            @test length(link_hrefs(refs, "foo-Tuple")) == 4
+            # foo appears in 5 call positions (one qualified); plain value
+            # mentions must not link.
+            @test length(link_hrefs(refs, "foo-Tuple")) == 5
+            # The qualified call's link wraps the name only.
+            @test occursin(
+                r"DocumenterCodeBlocks<span class=\"julia-operator\">\.</span><a class=\"julia-ref\" href=\"[^\"]*foo-Tuple\{Any\}\"[^>]*><span class=\"julia-funcall\">foo</span></a>",
+                refs,
+            )
             # `m::MyType` annotation + `MyType(3)` callee both link.
             @test length(link_hrefs(refs, "MyType")) == 2
             # An undocumented name stays plain.
             @test !occursin("undocumented_helper</a>", refs)
+        end
+
+        @testset "macro reference links" begin
+            # `@twice` is referenced unqualified, qualified, and as a call;
+            # `w"hello"` links through the `@w_str` name of the string macro.
+            @test length(link_hrefs(refs, "@twice")) == 3
+            @test length(link_hrefs(refs, "@w_str")) == 1
+            # The `@` sigil is inside the link; a qualified call's module
+            # prefix and dot stay outside it.
+            @test occursin(
+                r"julia-ref\" href=\"[^\"]*@twice\"[^>]*><span class=\"julia-macro\">@</span><span class=\"julia-macro\">twice</span></a>",
+                refs,
+            )
+            @test occursin(
+                r"DocumenterCodeBlocks<span class=\"julia-operator\">\.</span><a class=\"julia-ref\" href=\"[^\"]*@twice\"[^>]*><span class=\"julia-macro\">@</span><span class=\"julia-macro\">twice</span></a>",
+                refs,
+            )
+            # An undocumented macro is highlighted but not linked.
+            @test occursin("<span class=\"julia-macro\">undocumented_macro</span>", refs)
+            @test !occursin("undocumented_macro</span></a>", refs)
+            # Macros get tooltips like any other reference.
+            @test occursin(r"data-for=\"[^\"]*@twice\"><code class=\"ref-tip-sig", refs)
         end
 
         @testset "arity pruning and splats" begin
@@ -244,6 +331,11 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
             foo2 = docstring_details(index, "DocumenterCodeBlocks.foo-Tuple{Any, Any}")
             @test !occursin(selflink("DocumenterCodeBlocks.foo-Tuple{Any, Any}"), foo2)
             @test occursin(selflink("DocumenterCodeBlocks.foo-Tuple{Any}"), foo2)
+            # A macro name inside its own docstring is a self reference too,
+            # while other documented names in the block still link.
+            twice = docstring_details(index, "DocumenterCodeBlocks.@twice")
+            @test !occursin(selflink("DocumenterCodeBlocks.@twice"), twice)
+            @test occursin(selflink("DocumenterCodeBlocks.greet"), twice)
             # Constructor call in the type's own docstring is a self reference.
             @test !occursin(
                 selflink("DocumenterCodeBlocks.MyType"),
@@ -283,7 +375,7 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
             # and reference-linked.
             @test occursin("julia-keyword\">import</span>", skip)
             @test occursin(
-                r"julia-ref\" href=\"[^\"]*add_numbers\"[^>]*>DocumenterCodeBlocks<span class=\"julia-operator\">\.</span><span class=\"julia-funcall\">add_numbers</span></a>\(<span class=\"julia-number\">20</span>",
+                r"DocumenterCodeBlocks<span class=\"julia-operator\">\.</span><a class=\"julia-ref\" href=\"[^\"]*add_numbers\"[^>]*><span class=\"julia-funcall\">add_numbers</span></a>\(<span class=\"julia-number\">20</span>",
                 skip,
             )
             # Output segments keep their content, wrapped for ANSI color rules.


### PR DESCRIPTION
Macro names were highlighted but never linked: reference links only
attached to nodes in role-vouched positions (call callees, type
annotations), and a macro name is neither -- `@time` parses as a
`macrocall` whose head is the `@` trivia token plus a `MacroName` leaf.
`resolve_reference` also rejected anything but a symbol or a dotted name.

Link the name at the head of a `macrocall`, wrapping exactly the tokens
that spell it (the arguments keep their own links). No role gating is
needed: unlike a bare identifier, a macro name can only ever mean the
macro. Four shapes resolve -- `@time`, the qualified `Foo.@bar` (and the
legacy `@Foo.bar`), and string/command literals through the `@..._str` /
`@..._cmd` names their bindings carry. Arity is not passed along since
macro docstrings are bound with a `Union{}` signature.

Tooltips, self-reference suppression inside a macro's own docstring, and
REPL/@repl/doctest blocks all follow from the existing machinery.

Fixes #8.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
