### PR TITLE
Link identifiers used as values (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.2.0] - 2026-08-10
+## [v1.2.0] - 2026-08-11
 
 ### Added
  - Macro names in code blocks now link to their docstring, like function calls
    and type annotations already did. ([#8], [#10])
+ - Identifiers used as plain *values* — function arguments (`zero(T)`),
+   enum/constant mentions, the right-hand side of `=`, … — now link to their
+   docstring like call callees and type annotations already did. Names in
+   *binding* positions (left of `=`, function parameters, loop variables,
+   `local`/`const` declarations, …) are not uses and stay unlinked. ([#9],
+   [#12])
 
 ### Changed
  - Reference links on qualified names (`Foo.bar(...)`, `Foo.@bar`,
@@ -65,3 +71,5 @@ See [README.md](README.md) and the documentation for details.
 [#6]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/6
 [#8]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/8
 [#10]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/10
+[#9]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/9
+[#12]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/12

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -22,17 +22,20 @@ Hover (or click) `MyType`, `add_numbers`, and `greet` above — and note that
 `undocumented_helper` stays plain text: names that don't resolve are left
 alone, silently.
 
-Links only attach where the syntax vouches for the meaning: **call callees**
-(`add_numbers(...)`) and **type positions** (`m::MyType`). Plain value
-mentions and binding positions never link — without scope analysis, a local
-variable that shadows a documented name is indistinguishable from the real
-thing:
+Links attach to **call callees** (`add_numbers(...)`), **type positions**
+(`m::MyType`), and plain **value mentions** — a documented name used as a
+function argument, on the right of `=`, in a condition, and so on, like
+`zero(MyType)` or a documented constant. What never links is a **binding**:
+a name to the left of `=`, a function parameter, a loop variable — there the
+name is not a use of the documented object (in the block above, the parameter
+`m` binds and stays plain):
 
 ```julia
 a = foo(1)      # links the foo(a) docstring
 b = foo(1, 2)   # links the foo(a, b) docstring
-c = foo         # plain value mention → no link
+c = foo         # value mention → links, listing both methods
 d = DocumenterCodeBlocks.foo(1)   # qualified call
+foo = c         # binding (left of =) → no link
 ```
 
 As the block above shows, resolution is **arity-aware**: a call with `n`

--- a/src/DocumenterCodeBlocks.jl
+++ b/src/DocumenterCodeBlocks.jl
@@ -18,7 +18,8 @@ blocks), so no node/`prerender` is needed.
 
 - `languages`: which code-block languages to process.
 - `reference_links`: wrap identifiers that name a documented object in a link to
-  its docstring. Macro names link too.
+  its docstring. Macro names link too. Names in binding positions — left of
+  `=`, function parameters, loop variables, … — are not uses and never link.
 - `popups`: doxygen-style hover tooltips on reference links, embedded per page
   (no fetching): the target's signature and the docstring's first sentence.
   When a reference matches several documented methods (a bare identifier, a

--- a/src/juliasyntax.jl
+++ b/src/juliasyntax.jl
@@ -236,27 +236,54 @@ function _name_span(node)
     return (s, e)
 end
 
+# Binding contexts (issue #9): value-mention links are suppressed where a
+# name is being *bound* rather than used. Three shapes:
+# - assign-like nodes bind their LHS; from the operator token on, the RHS is
+#   ordinary value code again (this reset also un-binds nested RHSes, e.g. a
+#   default value inside a signature: `function f(x = default)`),
+# - definition-like nodes bind their signature part until the body,
+# - declaration-like nodes bind throughout (`local x`, `struct` fields,
+#   import/export lists, and the members of a dotted path — the whole path
+#   already resolved as one name).
+# Role-vouched links (call callees, type positions) are unaffected: `x::T = 1`
+# still links `T`, and a definition still links its own (documented) name.
+const _BIND_LHS = (K"=", K"op=", K"in", K"∈", K"->", K"iteration")
+const _BIND_SIG = (K"function", K"macro", K"module", K"baremodule")
+const _BIND_ALL = (
+    K"struct", K"abstract", K"primitive", K"local", K"global", K"const",
+    K"import", K"using", K"export", K"public", K".",
+)
+
 # The single recursive pass: emit `node` (at byte `offset`) under inherited `role`.
 # `arity` is the call argument count to pass to link resolution for a callee node
 # (or `nothing`), so a call links to the method with that many arguments.
 # `pref` is a pre-resolved reference handed down by a `macrocall` parent whose
 # name is this (dotted) node — the link is opened here so it can wrap just the
-# name part instead of the whole qualified path.
-function _emit!(io, cu, node, offset, role, arity, in_link, resolve, pref = nothing)
+# name part instead of the whole qualified path. `binding` marks a
+# binding position (see above): names there are not uses and get no value link.
+function _emit!(io, cu, node, offset, role, arity, in_link, resolve, pref = nothing, binding = false)
     k = _JS.kind(node)
     r = _noderange(offset, node)
 
-    # Only positions whose syntactic role vouches for the meaning get reference
-    # links: call/dotcall callees (:funcall) and type positions (:type). Plain
-    # value mentions (`x = foo`, `map(foo, xs)`) and binding positions (LHS of
-    # `=`, definition parameters, kwarg names) stay plain — without scope
-    # analysis we can't tell a documented name from a local that shadows it.
+    # Positions whose syntactic role vouches for the meaning — call/dotcall
+    # callees (:funcall) and type positions (:type) — link arity-aware. Plain
+    # value mentions (`x = foo`, `map(foo, xs)`, `zero(T)`) link too, unless
+    # the position binds the name (`binding`).
     linkable = role === :funcall || role === :type
 
     if _JS.is_leaf(node)
         name = k == K"Identifier" ? Symbol(_text(cu, r)) : Symbol("")
         face = _leaf_face(k, role, name, _JS.is_trivia(node))
-        ref = (linkable && !in_link && resolve !== nothing && k == K"Identifier") ? resolve(_text(cu, r), arity) : nothing
+        ref = nothing
+        if !in_link && resolve !== nothing && k == K"Identifier"
+            if linkable
+                ref = resolve(_text(cu, r), arity)
+            elseif face === :none && !binding
+                # A bare identifier used as a value (issue #9). The :none-face
+                # gate keeps operators, quoted symbols, and singletons plain.
+                ref = resolve(_text(cu, r), nothing)
+            end
+        end
         _emit_leaf(io, _text(cu, r), face, ref)
         return
     end
@@ -264,10 +291,11 @@ function _emit!(io, cu, node, offset, role, arity, in_link, resolve, pref = noth
     # A dotted name (Foo.bar) resolves as a whole, but the link wraps only the
     # trailing name — the module qualifier and dot stay outside. `pref` is the
     # already-resolved reference when a macrocall parent delegated its dotted
-    # name here.
+    # name here. Value mentions of dotted names link like bare ones do.
     dotref = pref
-    if dotref === nothing && linkable && !in_link && resolve !== nothing &&
-            k == K"." && _is_dotted_name(node)
+    if dotref === nothing && !in_link && resolve !== nothing &&
+            k == K"." && _is_dotted_name(node) &&
+            (linkable || (role === :none && !binding))
         dotref = resolve(_text(cu, r), arity)
     end
     dotspan = dotref === nothing ? nothing : _name_span(node)
@@ -304,6 +332,10 @@ function _emit!(io, cu, node, offset, role, arity, in_link, resolve, pref = noth
     symbol_quote = k == K"quote" && _is_symbol_quote(node)
     seen_coloncolon = false
     callee_done = false
+    seen_op = false        # assign-like: the `=`/`in`/`->` token was passed
+    body_started = false   # definition-like: the body block (or short-form `=`) was reached
+    let_bound = false      # let: only the first block holds the bindings
+    after_where = false    # where: the introduced type variables bind
 
     o, i = offset, 0
     for c in _JS.children(node)
@@ -330,6 +362,29 @@ function _emit!(io, cu, node, offset, role, arity, in_link, resolve, pref = noth
             crole = (i == last_ident) ? role : :none      # only the last id carries the role
             carity = (i == last_ident) ? arity : nothing
         end
+        # Binding context for this child (see _BIND_* above). Inherited by
+        # default; LHS/signature/declaration positions set it, and the value
+        # side of an assign-like node resets it.
+        cbind = binding
+        if k in _BIND_LHS
+            cbind = !seen_op
+            kc in (K"=", K"in", K"∈", K"->") && (seen_op = true)
+        elseif k in _BIND_SIG
+            kc == K"block" && (body_started = true)       # the block IS the body
+            cbind = !body_started
+            kc == K"=" && (body_started = true)           # short form: `f(x) = body`
+        elseif k in _BIND_ALL
+            cbind = true
+        elseif k == K"let"
+            (kc == K"block" && !let_bound) && ((cbind, let_bound) = (true, true))
+        elseif k == K"do"
+            kc == K"tuple" && (cbind = true)              # the do-block arguments
+        elseif k == K"catch"
+            kc != K"block" && (cbind = true)              # `catch e` binds e
+        elseif k == K"where"
+            cbind = after_where
+            kc == K"where" && (after_where = true)
+        end
         # The link wraps the children in `dotspan`/the macro-name span; the
         # other children of a linked node are emitted `in_link` anyway so the
         # name resolves once, as a whole (no stray link on a module prefix).
@@ -342,7 +397,7 @@ function _emit!(io, cu, node, offset, role, arity, in_link, resolve, pref = noth
         (wrapname && i == macroname.first) && _print_ref_open(io, macroref)
         _emit!(
             io, cu, c, o, crole, carity,
-            in_link || wrapname || dotspan !== nothing, resolve, cpref,
+            in_link || wrapname || dotspan !== nothing, resolve, cpref, cbind,
         )
         (wrapname && i == macroname.last) && print(io, "</a>")
         (indot && i == dotspan[2]) && print(io, "</a>")

--- a/test/docsite/src/references.md
+++ b/test/docsite/src/references.md
@@ -9,9 +9,10 @@ should resolve to their docstrings (defined on the [home page](@ref "DocumenterC
 
 This block uses documented names (`add_numbers`, `greet`, `MyType`) that the
 plugin should turn into links to their docstring anchors, plus an undocumented
-name (`undocumented_helper`) that must stay plain text. Links only attach where
-the syntax vouches for the meaning — call callees and type annotations (like the
-`m::MyType` argument below); plain value mentions stay unlinked (see below).
+name (`undocumented_helper`) that must stay plain text. Call callees, type
+annotations (like the `m::MyType` argument below), and plain value mentions
+all link; names in binding positions — like the parameter `m` — do not (see
+below).
 
 ```julia
 function demo(m::MyType)
@@ -43,14 +44,17 @@ s = w"hello"                         # string macro
 
 `foo` has two documented methods, [`foo(a)`](@ref) and [`foo(a, b)`](@ref), each
 with its own docstring. Call sites link arity-aware; a plain value mention of
-`foo` is not a call (and could be a local shadowing the documented name), so it
-stays unlinked.
+`foo` links too (with the unknown-arity candidate list), but a **binding** of
+the name — left of `=`, a parameter, a loop variable — is not a use and stays
+unlinked.
 
 ```julia
 a = foo(1)      # links the foo(a) docstring
 b = foo(1, 2)   # links the foo(a, b) docstring
-c = foo         # plain value mention → no link
+c = foo         # value mention → links (both methods listed)
 d = DocumenterCodeBlocks.foo(1)   # qualified call: the link is on the name only
+e = map(foo, [1, 2])              # passed as a value → links
+foo = c         # binding position (left of =) → no link
 ```
 
 ## Hover popups

--- a/test/playwright/verify-popup.js
+++ b/test/playwright/verify-popup.js
@@ -49,10 +49,10 @@ function check(name, ok, extra) {
   check("ambiguous links carry data-ref-targets", nAmbig >= 2, `found ${nAmbig}`);
 
   // --- role gating: only callees and type positions link -------------------
-  // foo appears in 5 call positions (one qualified); the plain value mentions
-  // (`c = foo`) must NOT produce links, so exactly 5 foo links exist.
+  // foo links from 5 call positions and 2 value mentions; the binding
+  // (`foo = c`) must NOT produce a link, so exactly 7 foo links exist.
   const nFoo = await page.locator('a.julia-ref[href*="foo-Tuple"]').count();
-  check("plain value mentions are not linked (5 foo call links)", nFoo === 5, `found ${nFoo}`);
+  check("value mentions link, bindings do not (7 foo links)", nFoo === 7, `found ${nFoo}`);
   // `m::MyType` annotation + `MyType(3)` callee both link.
   const nMyType = await page.locator('a.julia-ref[href$="MyType"]').count();
   check("type annotations link (2 MyType links)", nMyType >= 2, `found ${nMyType}`);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,17 +66,27 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
         @test !occursin("<span class=\"julia-funcall\">f</span> (generic", r2)
     end
 
-    @testset "macro names" begin
-        # A stub resolver records the names asked for and links every one, so
-        # the shapes of macro-name references can be checked without a build.
+    # An allowlist stub resolver: records every name link resolution is asked
+    # for, and links exactly the allowed ones — so link shapes can be checked
+    # without a docsite build.
+    function mkstub(allowed...)
         asked = String[]
-        function stub(name, arity)
+        stub = function (name, arity)
             push!(asked, name)
+            name in allowed || return nothing
             t = (href = "#$name", tipkey = "#$name", label = name, sig = name, brief = nothing)
             return (href = t.href, targets = [t])
         end
+        return asked, stub
+    end
+    link(name) = "<a class=\"julia-ref\" href=\"#$name\">"
+
+    @testset "macro names" begin
+        asked, stub = mkstub(
+            "@time", "f", "Foo.@bar", "@Foo.bar", "@raw_str", "@x_cmd",
+            "Foo.@bar_str", "Foo.Sub.@bar_cmd", "Foo.bar", "Foo.Bar",
+        )
         h(src) = DCB.highlight_julia_html(src; resolve = stub)
-        link(name) = "<a class=\"julia-ref\" href=\"#$name\">"
         # The `@` sigil is part of the link, and the arguments are not.
         @test h("@time f(x)") ==
             link("@time") * "<span class=\"julia-macro\">@</span>" *
@@ -118,10 +128,48 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
                 "<span class=\"julia-type\">Bar</span></a>",
         )
         empty!(asked)
-        h("@show(a, b)\n@__MODULE__\nf(@view A[1])\nx::@NamedTuple{a::Int}")
-        @test asked == ["@show", "@__MODULE__", "f", "@view", "@NamedTuple", "Int"]
+        h("@show(a, b)\n@__MODULE__\nf(@view A[1])")
+        # Macro names, callees, and value mentions (the macro arguments) all
+        # ask for resolution.
+        @test asked == ["@show", "a", "b", "@__MODULE__", "f", "@view", "A"]
         # Nothing links without a resolver (docstring signature headers).
         @test !occursin("julia-ref", DCB.highlight_julia_html("@time f(x)"))
+    end
+
+    @testset "value mentions and bindings" begin
+        # Value positions link (issue #9); binding positions do not.
+        _, stub = mkstub("foo", "T", "Foo.bar")
+        h(src) = DCB.highlight_julia_html(src; resolve = stub)
+        # RHS of `=`, call arguments, conditions, ternary branches: values.
+        @test h("x = foo") ==
+            "x <span class=\"julia-keyword\">=</span>" * " " * link("foo") * "foo</a>"
+        @test h("zero(T)") ==
+            "<span class=\"julia-funcall\">zero</span>(" * link("T") * "T</a>)"
+        @test occursin(link("foo") * "foo</a>, xs", h("map(foo, xs)"))
+        @test occursin(link("foo"), h("if foo\nend"))
+        @test occursin(link("Foo.bar") * "bar</a>", h("x = Foo.bar"))
+        @test occursin(link("foo"), h("f(a; kw = foo)"))       # kwarg VALUE
+        # Binding positions: LHS of (op-)assignment, parameters, loop
+        # variables, declarations, do/lambda arguments, catch, field access.
+        for src in (
+                "foo = 1", "foo += 1", "foo, T = 1, 2", "for foo in xs\nend",
+                "[i for foo in xs]", "foo -> 1", "local foo", "const foo = 1",
+                "struct foo\n    T::Int\nend", "import Foo: foo", "using foo",
+                "export foo", "try f() catch foo\nend", "f(foo = 1)",
+                "foo[1] = x", "foo.x = 1", "t.foo",
+            )
+            @test !occursin("julia-ref", h(src))
+        end
+        # The value side of a binding context is ordinary code again: bodies
+        # link, and so does the RHS of a `let`/`const`/default-value `=`.
+        @test occursin(link("foo") * "foo</a>\n", h("function g(foo)\n    foo\nend"))
+        @test occursin(link("foo"), h("g(foo) = foo + 1"))
+        @test occursin(link("T"), h("const foo = T"))
+        @test count("julia-ref", h("let foo = T\n    foo\nend")) == 2   # T + body foo
+        @test occursin(link("foo") * "foo</a>\n", h("map(xs) do foo\n    foo\nend"))
+        # Role-vouched links are unaffected by binding contexts: the annotated
+        # parameter's type still links inside a signature.
+        @test occursin(link("T") * "<span class=\"julia-type\">T</span></a>", h("g(x::T) = x"))
     end
 
     @testset "split_highlighted" begin
@@ -212,9 +260,17 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
         ]
 
         @testset "role-gated reference links" begin
-            # foo appears in 5 call positions (one qualified); plain value
-            # mentions must not link.
-            @test length(link_hrefs(refs, "foo-Tuple")) == 5
+            # foo links from 5 call positions (one qualified) plus 2 value
+            # mentions (`c = foo`, `map(foo, …)`); the binding `foo = c` and
+            # the plain-text mentions must not link.
+            @test length(link_hrefs(refs, "foo-Tuple")) == 7
+            # The value mention has an unknown arity: both methods listed.
+            @test occursin(
+                r"c <span class=\"julia-keyword\">=</span> <a class=\"julia-ref\" href=\"[^\"]*foo-Tuple\{Any\}\"[^>]*data-ref-targets",
+                refs,
+            )
+            # The binding stays plain: `foo = c` emits no link around foo.
+            @test occursin(r"\bfoo <span class=\"julia-keyword\">=</span> c\b", refs)
             # The qualified call's link wraps the name only.
             @test occursin(
                 r"DocumenterCodeBlocks<span class=\"julia-operator\">\.</span><a class=\"julia-ref\" href=\"[^\"]*foo-Tuple\{Any\}\"[^>]*><span class=\"julia-funcall\">foo</span></a>",


### PR DESCRIPTION
Reference links were role-gated: only call callees and type positions
linked, so a documented name used as a plain value -- a function argument
(`zero(T)`), an enum or constant mention, the right-hand side of `=` --
stayed plain (issue #9).

Value mentions now link too, bare and qualified alike, resolved with
unknown arity so multi-method functions get the candidate-list popup.
What never links is a name in a *binding* position, where it is being
bound rather than used: the LHS of (op-)assignment and destructuring,
function/macro/lambda/do parameters, loop and generator variables,
local/global/const declarations, struct names and fields, catch
variables, where type-vars, import/using/export lists, kwarg names at
call sites, and (conservatively) the whole LHS of `a[i] = v` and
`t.x = v`. The value side of a binding context is ordinary code again:
bodies, default values, and the RHS of `=` all link.

Implemented as a `binding` flag threaded through the emitter with three
context shapes: bind-until-the-operator-token (`=`, `in`, `->`),
bind-until-the-body (function/macro/module), and bind-throughout
(declarations, import lists, dotted paths). The :none-face gate keeps
operators, quoted symbols, and singletons plain, and role-vouched links
are unaffected (`x::T = 1` still links `T`).

Fixes #9.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
