### PR TITLE
Positional page meta: @codeblocks options and per-block CurrentModule (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.3.0] - 2026-08-12
+
+### Added
+ - New `@codeblocks` block for page-local plugin options, applied
+   positionally like `@meta`. The first option is `line_counter`:
+   `:continue` carries one running line counter across the page's code
+   blocks (tutorial style), and `:named` keeps one counter per named series
+   (`@example name`, `@repl name`, `jldoctest name`, …) with unnamed blocks
+   restarting — instead of the default `:restart` numbering from 1. The
+   site-wide default mode is configurable with `CodeBlocks(line_counter = …)`.
+   Line permalinks use the displayed numbers. Blocks inside docstrings are
+   their own page: they always start at 1 and do not advance any counter.
+   ([#14])
+ - Reference resolution now follows `@meta CurrentModule` **positionally**,
+   exactly like `@ref`: a mid-page module switch applies from its position
+   on, and code blocks inside a docstring resolve in the docstring's own
+   module. Previously the page-final state applied everywhere. ([#14])
+
 ## [v1.2.0] - 2026-08-12
 
 ### Added
@@ -22,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    now candidate-aware: a reference is left unlinked whenever the enclosing
    docstring is among its candidate targets, not only when it is the primary
    target. ([#11], [#13])
-
 ### Changed
  - Reference links on qualified names (`Foo.bar(...)`, `Foo.@bar`,
    `x::Foo.Bar`) now wrap only the name; the module qualifier and dot stay
@@ -72,6 +89,7 @@ See [README.md](README.md) and the documentation for details.
 [v1.0.1]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.0.1
 [v1.1.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.1.0
 [v1.2.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.2.0
+[v1.3.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.3.0
 [#3]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/3
 [#5]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/5
 [#6]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/6
@@ -81,3 +99,4 @@ See [README.md](README.md) and the documentation for details.
 [#11]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/11
 [#12]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/12
 [#13]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/13
+[#14]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/14

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocumenterCodeBlocks"
 uuid = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Fredrik Ekre <ekrefredrik@gmail.com>"]
 
 [deps]

--- a/assets/line-numbers.js
+++ b/assets/line-numbers.js
@@ -14,6 +14,11 @@
  * Hash formats:  #c-1a2b3c4d          whole block
  *                #c-1a2b3c4d-L5       single line
  *                #c-1a2b3c4d-L5-L10   line range
+ *
+ * L-numbers are the DISPLAYED line numbers. A block whose numbering continues
+ * from earlier blocks on the page (`@codeblocks line_counter = :continue`)
+ * carries data-ln-start on its .code-lines wrapper; internally everything is
+ * a 1-based child index, converted at the hash boundary.
  */
 (function () {
   "use strict";
@@ -53,7 +58,18 @@
 
   // ---- gutter interactions ---------------------------------------------
 
+  // First displayed line number of the block (data-ln-start, default 1).
+  function lnStart(pre) {
+    const wrap = pre.querySelector(".code-lines");
+    const start = wrap && wrap.dataset.lnStart ? parseInt(wrap.dataset.lnStart, 10) : 1;
+    return isNaN(start) ? 1 : start;
+  }
+
+  // `a`/`b` are 1-based child indices; the hash carries displayed numbers.
   function rangeHash(pre, a, b) {
+    const off = lnStart(pre) - 1;
+    a += off;
+    b += off;
     return a === b ? "#" + pre.id + "-L" + a : "#" + pre.id + "-L" + a + "-L" + b;
   }
 
@@ -146,7 +162,8 @@
   function highlightRange(pre, a, b) {
     clearHighlights();
     const lines = pre.querySelectorAll(".line");
-    for (let n = a; n <= b && n <= lines.length; n++) {
+    // Clamp: a stale hash (e.g. numbering offsets changed) must not throw.
+    for (let n = Math.max(a, 1); n <= b && n <= lines.length; n++) {
       lines[n - 1].classList.add("hl");
     }
   }
@@ -162,8 +179,10 @@
       if (scroll) pre.scrollIntoView({ block: "center" });
       return;
     }
-    const a = Math.min(+m[2], m[3] ? +m[3] : +m[2]);
-    const b = Math.max(+m[2], m[3] ? +m[3] : +m[2]);
+    // Hash numbers are displayed numbers; convert to child indices.
+    const off = lnStart(pre) - 1;
+    const a = Math.min(+m[2], m[3] ? +m[3] : +m[2]) - off;
+    const b = Math.max(+m[2], m[3] ? +m[3] : +m[2]) - off;
     highlightRange(pre, a, b);
     const lines = pre.querySelectorAll(".line");
     if (scroll && lines[a - 1]) lines[a - 1].scrollIntoView({ block: "center" });

--- a/docs/src/linenumbers.md
+++ b/docs/src/linenumbers.md
@@ -48,6 +48,75 @@ julia> norm2(p)
 25.0
 ```
 
+## Continued numbering
+
+By default every block numbers from 1. A page can instead carry **one running
+line counter** across its code blocks — tutorial style — by placing an
+`@codeblocks` options block:
+
+````markdown
+```@codeblocks
+line_counter = :continue
+```
+````
+
+Like `@meta`, the setting applies from its position to the end of the page,
+or until another `@codeblocks` block flips it back to `:restart` (the
+default). All processed blocks participate — `julia`, `julia-repl`, and
+executed `@repl` blocks — and line permalinks use the displayed numbers, so
+a copied `#…-L12` link keeps meaning the line the reader saw. The two blocks
+below share one counter:
+
+```@codeblocks
+line_counter = :continue
+```
+
+```julia
+grid = [Point(float(i), float(j)) for i in 1:3, j in 1:3]
+origin = Point(0.0, 0.0)
+```
+
+```julia
+nearest = closest(vec(grid), origin)
+r2 = norm2(nearest)
+```
+
+```@codeblocks
+line_counter = :restart
+```
+
+A third mode, `line_counter = :named`, keeps one counter **per named
+series**: blocks that share a name — `@example tutorial`, `@repl tutorial`,
+`jldoctest tutorial`, or a plain fence with a second token like
+```` ```julia tutorial ```` — continue each other (across block kinds and
+across unrelated blocks in between), while unnamed blocks restart. This
+pairs naturally with Documenter's named `@example`/`@repl` sandboxes, where
+same-named blocks already share one session:
+
+```@codeblocks
+line_counter = :named
+```
+
+```@example numbering-demo
+total = 1 + 2
+nothing # hide
+```
+
+An unnamed block between the two restarts at 1, but the series picks up
+where it left off:
+
+```@example numbering-demo
+total += 3
+nothing # hide
+```
+
+```@codeblocks
+line_counter = :restart
+```
+
+Blocks inside docstrings are their own page: they always start at 1 and
+never advance any counter.
+
 ## Configuration
 
 All knobs are keyword arguments of [`CodeBlocks`](@ref):
@@ -56,6 +125,9 @@ All knobs are keyword arguments of [`CodeBlocks`](@ref):
   and linked, and keep their id + permalink),
 - `repl_line_numbers = false` disables the gutter for `julia-repl` blocks
   only,
+- `line_counter` sets the site-wide default line-counter mode (`:restart`,
+  `:continue`, or `:named`) — `@codeblocks` blocks override it per page,
+  positionally,
 - `min_lines` sets the minimum block length that gets a gutter — the default
   `1` numbers everything, including one-liners:
 
@@ -64,4 +136,5 @@ answer = add_numbers(40, 2)
 ```
 
 The signature header of a rendered docstring is deliberately **not** numbered
-(nor linked) — it is a header, not example code.
+— it is a header, not example code (its argument and return types do get
+reference links, though — see [Reference links](@ref references)).

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -7,7 +7,11 @@ CurrentModule = DocumenterCodeBlocks
 Identifiers in code blocks that name a **documented object** become links to
 the docstring — the code-block equivalent of Documenter's `@ref`. Resolution
 uses the same machinery and the page's `CurrentModule` meta, so a code block
-and an `@ref` link always agree on the target.
+and an `@ref` link always agree on the target. `CurrentModule` applies
+**positionally**, exactly as it does for `@ref`: a page can switch modules
+with a second `@meta` block halfway down, and each code block resolves in the
+module in effect at its own position. Code blocks inside a docstring resolve
+in the docstring's own module, wherever the docstring is spliced.
 
 ```julia
 function demo(m::MyType)

--- a/src/DocumenterCodeBlocks.jl
+++ b/src/DocumenterCodeBlocks.jl
@@ -8,8 +8,19 @@ export CodeBlocks
 # Plugin configuration
 # ---------------------------------------------------------------------------
 
+# The meta state a code block sees at its position on the page: the module
+# reference resolution happens in, the line-numbering mode, and the block's
+# series name (`@example name`, `@repl name`, `jldoctest name`, or the second
+# fence token of a plain block) for `line_counter = :named`.
+struct BlockMeta
+    mod::Module
+    line_counter::Symbol   # :restart | :continue | :named
+    name::Union{String, Nothing}
+end
+BlockMeta(mod::Module, line_counter::Symbol) = BlockMeta(mod, line_counter, nothing)
+
 """
-    CodeBlocks(; languages=["julia"], reference_links=true, popups=true, line_numbers=true, repl_line_numbers=true, min_lines=1)
+    CodeBlocks(; languages=["julia"], reference_links=true, popups=true, line_numbers=true, repl_line_numbers=true, min_lines=1, line_counter=:restart)
 
 Documenter plugin that enhances code blocks with syntax highlighting, line
 numbers / linkable lines, and reference links — all in a single pass. Julia is
@@ -31,6 +42,31 @@ blocks), so no node/`prerender` is needed.
   blocks and REPL-style `jldoctest`s). Requires `line_numbers=true`.
 - `min_lines`: blocks with fewer lines get an id + permalink but no gutter
   (the default numbers every block, including one-liners).
+- `line_counter`: the default line-counter mode for every page — `:restart`,
+  `:continue`, or `:named` (see the `@codeblocks` block below, which overrides
+  it per page, positionally).
+
+Reference resolution follows the page's `@meta CurrentModule` **positionally**,
+exactly like `@ref`: the module in effect at a block's position applies to that
+block, and code blocks inside a docstring resolve in the docstring's own module.
+
+Pages can configure the plugin locally with an `@codeblocks` block:
+
+````markdown
+```@codeblocks
+line_counter = :continue
+```
+````
+
+- `line_counter`: `:restart` (default) numbers every block from 1;
+  `:continue` carries one running line counter across the page's code blocks
+  (`julia`, `julia-repl`, executed `@repl`), tutorial-style; `:named` keeps
+  one counter **per named series** — blocks sharing a name (`@example name`,
+  `@repl name`, `jldoctest name`, or a second fence token like
+  ` ```julia name `) continue each other, while unnamed blocks restart. Like
+  `@meta`, the setting applies from its position to the end of the page (or
+  the next `@codeblocks` block). Blocks inside docstrings are their own page:
+  they always start at 1 and do not advance any counter.
 
 The first code block of a docstring — the signature header — gets no line
 numbers or permalink (headers aren't always valid Julia, e.g. `f(x[, y])`),
@@ -55,16 +91,38 @@ struct CodeBlocks <: Documenter.Plugin
     line_numbers::Bool
     repl_line_numbers::Bool
     min_lines::Int
+    line_counter::Symbol   # default line-counter mode: :restart | :continue | :named
     # Internal: crc32c hashes of the sources of `jldoctest`-fenced blocks, collected
     # before RenderDocument rewrites the fence to julia/julia-repl. Used to apply the
     # script-style `# output` split only to real doctests (like Documenter does).
     jldoctests::Set{UInt32}
+    # Internal: per-block metadata collected positionally from each page's AST
+    # (ScanStep): page key → (block kind, source hash) → FIFO queue of one entry
+    # per occurrence, in document order. Gives every block the meta state AT ITS
+    # POSITION — the resolution module (`@meta CurrentModule`, or the docstring's
+    # own module) and the line-counter mode (`@codeblocks line_counter`) — the
+    # way Documenter itself applies meta positionally for `@ref`/`@docs`.
+    blockmeta::Dict{String, Dict{Tuple{Symbol, UInt32}, Vector{BlockMeta}}}
     # Internal: dedup keys of already-emitted "CodeBlocks: " build warnings, so
     # each extraction problem is reported once per build (not per page/reference).
     warned::Set{String}
 end
-function CodeBlocks(; languages = ["julia"], reference_links = true, popups = true, line_numbers = true, repl_line_numbers = true, min_lines = 1)
-    return CodeBlocks(languages, reference_links, popups, line_numbers, repl_line_numbers, min_lines, Set{UInt32}(), Set{String}())
+function CodeBlocks(;
+        languages = ["julia"], reference_links = true, popups = true, line_numbers = true,
+        repl_line_numbers = true, min_lines = 1, line_counter = :restart,
+    )
+    line_counter isa Symbol && line_counter in (:restart, :continue, :named) || throw(
+        ArgumentError(
+            "CodeBlocks: invalid `line_counter` value `$(repr(line_counter))`; " *
+                "expected :restart, :continue, or :named",
+        ),
+    )
+    return CodeBlocks(
+        languages, reference_links, popups, line_numbers, repl_line_numbers, min_lines,
+        line_counter,
+        Set{UInt32}(), Dict{String, Dict{Tuple{Symbol, UInt32}, Vector{BlockMeta}}}(),
+        Set{String}(),
+    )
 end
 
 include("split.jl")

--- a/src/juliasyntax.jl
+++ b/src/juliasyntax.jl
@@ -441,12 +441,14 @@ end
 # links.
 # Every target that resolves is also recorded (deduplicated by href) in the
 # page-level `tips` collector, which becomes the page's hidden tooltip payload.
-function make_resolver(plugin, doc, page, tips = nothing, self_ids = nothing)
+# `mod` is the module this block's references resolve in (positional
+# `CurrentModule` / the docstring's own module); `nothing` = page-final state.
+function make_resolver(plugin, doc, page, tips = nothing, self_ids = nothing, mod = nothing)
     plugin.reference_links || return nothing
     cache = Dict{Tuple{String, Union{Int, AtLeast, Nothing}}, Any}()
     isself(href, ids) = any(id -> href == "#" * id, ids)
     return function (name, arity)
-        r = get!(() -> resolve_reference(name, doc, page, arity, plugin), cache, (name, arity))
+        r = get!(() -> resolve_reference(name, doc, page, arity, plugin, mod), cache, (name, arity))
         r !== nothing && self_ids !== nothing &&
             (isself(r.href, self_ids) || any(t -> isself(t.href, self_ids), r.targets)) &&
             return nothing
@@ -497,9 +499,9 @@ const _OUTPUT_RE = r"^# output$"m
 # was `jldoctest`-fenced), matching Documenter's fence-first rule.
 function highlight_julia_lines(
         source::AbstractString, plugin, doc, page;
-        jldoctest::Bool = false, tips = nothing, self_ids = nothing,
+        jldoctest::Bool = false, tips = nothing, self_ids = nothing, mod = nothing,
     )
-    resolve = make_resolver(plugin, doc, page, tips, self_ids)
+    resolve = make_resolver(plugin, doc, page, tips, self_ids, mod)
     m = jldoctest ? match(_OUTPUT_RE, source) : nothing
     html = if m === nothing
         highlight_julia_html(source; resolve = resolve)

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -10,38 +10,214 @@ abstract type CodeBlocksStep <: DocumentPipeline end
 
 Selectors.order(::Type{CodeBlocksStep}) = 6.5   # after RenderDocument (6.0)
 
-# Scan the AST for `jldoctest`-fenced blocks and record each block's source hash.
-# Documenter's `doctest_replace!` (in the Populate step, order 5.0) rewrites the
-# fence to julia/julia-repl, so we must run after ExpandTemplates (2.0, docstrings
-# expanded) but before Populate (5.0), while the `jldoctest` fence still exists.
-# This lets the post-render step apply the script-style `# output` split only to
-# real doctests — matching Documenter's fence-first rule.
-abstract type JldoctestScanStep <: DocumentPipeline end
+# ---------------------------------------------------------------------------
+# The `@codeblocks` block: page-local plugin options, positional like `@meta`
+# ---------------------------------------------------------------------------
+#
+#     ```@codeblocks
+#     line_counter = :continue
+#     ```
+#
+# Documenter warns about unknown keys in `@meta` blocks (hard-coded allowlist
+# in its MetaBlocks expander), so the plugin brings its own meta-like block.
+# The expanded node reuses `Documenter.MetaNode`: the HTML writer renders a
+# MetaNode as nothing, Documenter's own meta walkers merge its dict harmlessly,
+# and the ScanStep below picks the settings up positionally, exactly like
+# `@meta`. The dict key is CodeBlocks-prefixed only because all MetaNode dicts
+# — ours and `@meta`'s — merge into the same positional state; users never
+# write it.
 
-Selectors.order(::Type{JldoctestScanStep}) = 4.5   # after ExpandTemplates (2.0), before Populate (5.0)
+abstract type CodeBlocksExpander <: Documenter.Expanders.ExpanderPipeline end
 
-function Selectors.runner(::Type{JldoctestScanStep}, doc::Documenter.Document)
+Selectors.order(::Type{CodeBlocksExpander}) = 2.05   # right after MetaBlocks (2.0)
+Selectors.matcher(::Type{CodeBlocksExpander}, node, page, doc) =
+    Documenter.iscode(node, "@codeblocks")
+
+const _LINE_COUNTER_KEY = :CodeBlocksLineCounter
+
+# The option value: only `:symbol` literals are accepted (matching the
+# Symbol-typed global options of `CodeBlocks`).
+_option_symbol(v::QuoteNode) = v.value isa Symbol ? v.value : nothing
+_option_symbol(v) = nothing
+
+function Selectors.runner(::Type{CodeBlocksExpander}, node, page, doc)
+    x = node.element
+    settings = Dict{Symbol, Any}()
+    lines = Documenter.find_block_in_file(x.code, page.source)
+    for (ex, _) in Documenter.parseblock(x.code, doc, page; lines = lines)
+        Documenter.isassign(ex) || continue
+        key, value = ex.args[1], ex.args[2]
+        if key === :line_counter
+            mode = _option_symbol(value)
+            if mode in (:restart, :continue, :named)
+                settings[_LINE_COUNTER_KEY] = mode
+            else
+                @warn string(
+                    "CodeBlocks: invalid `line_counter` value `", value,
+                    "` in `@codeblocks` block in ", Documenter.locrepr(doc, page, lines),
+                    "; expected :restart, :continue, or :named.",
+                )
+            end
+        else
+            @warn string(
+                "CodeBlocks: unknown `@codeblocks` option `", key, "` in ",
+                Documenter.locrepr(doc, page, lines), ".",
+            )
+        end
+    end
+    node.element = Documenter.MetaNode(x, settings)
+    return
+end
+
+# ---------------------------------------------------------------------------
+# Positional per-block metadata scan
+# ---------------------------------------------------------------------------
+#
+# Walk each page's AST in document order, carrying the meta state — the
+# resolution module (`@meta CurrentModule`) and the line-counter mode
+# (`@codeblocks line_counter`) — and record, per code block, the state AT ITS
+# POSITION. This mirrors how Documenter itself applies meta positionally
+# (cross_references.jl re-walks pages merging each MetaNode in order, and
+# overrides CurrentModule with the docstring's own module inside docstrings).
+# The post-render step can then give every block the same resolution `@ref`
+# would use, and the page-local line-counter mode.
+#
+# The scan also records the crc32c of `jldoctest`-fenced block sources:
+# Documenter's `doctest_replace!` (Populate, order 5.0) rewrites the fence to
+# julia/julia-repl, so this must run after ExpandTemplates (2.0, docstrings and
+# `@repl`/`@example` expanded) but before Populate (5.0), while the fence still
+# exists. That lets the post-render step apply the script-style `# output`
+# split only to real doctests — matching Documenter's fence-first rule.
+abstract type ScanStep <: DocumentPipeline end
+
+Selectors.order(::Type{ScanStep}) = 4.5   # after ExpandTemplates (2.0), before Populate (5.0)
+
+function Selectors.runner(::Type{ScanStep}, doc::Documenter.Document)
     plugin = Documenter.getplugin(doc, CodeBlocks)
+    # Every page starts from the global defaults: `makedocs(meta = …)` seeds
+    # each page's meta (like Documenter's expanders), and the plugin's
+    # `line_counter` option is the site-wide default — both overridden
+    # positionally by the page's own `@meta`/`@codeblocks` blocks.
+    init = BlockMeta(get(doc.user.meta, :CurrentModule, Main), plugin.line_counter)
     for page in values(doc.blueprint.pages)
-        scan_jldoctests!(plugin.jldoctests, page.mdast)
+        scan_page!(plugin, page_key(doc, page), page.mdast, init)
     end
     return
 end
 
-function scan_jldoctests!(set::Set{UInt32}, node)
+# The block kind, matching which post-render pass will consume the block:
+# `:block` (language-julia), `:repl` (language-julia-repl), or `nothing`
+# (a language the plugin does not process). A `jldoctest` fence renders as
+# julia-repl iff it contains a `julia> ` prompt — Documenter's own rule
+# (doctests.jl), mirrored so the queues line up with the rendered HTML.
+function _block_kind(el)
+    langs = split(el.info; limit = 2)   # empty for a bare ``` fence
+    lang = isempty(langs) ? "" : langs[1]
+    lang == "julia" && return :block
+    lang == "julia-repl" && return :repl
+    startswith(lang, "jldoctest") &&
+        return occursin(r"^julia> "m, el.code) ? :repl : :block
+    return nothing
+end
+
+function _record_blockmeta!(plugin, pagekey, kind, hash, state)
+    pagedict = get!(Dict{Tuple{Symbol, UInt32}, Vector{BlockMeta}}, plugin.blockmeta, pagekey)
+    push!(get!(Vector{BlockMeta}, pagedict, (kind, hash)), state)
+    return
+end
+
+# The block's series name for `line_counter = :named`: the second token of the
+# fence info string (`jldoctest name`, `@example name`, `@repl name`, or a
+# plain ```` ```julia name ```` — the writer renders only the first token, so
+# the name never shows up in the output). Token syntax `[^\s;]+` matches
+# Documenter's own name parsing; `nothing` for an unnamed block.
+function _fence_name(info)
+    m = match(r"^\s*[^\s;]+\s+([^\s;]+)", info)
+    return m === nothing ? nothing : String(m.captures[1])
+end
+
+# Sequential fold over the tree: returns the (possibly updated) meta state so
+# a MetaNode affects everything after it, while sub-scopes (docstrings, @eval
+# results) cannot leak state back out.
+function scan_page!(plugin, pagekey, node, state)
     el = node.element
-    if el isa Documenter.MarkdownAST.CodeBlock && startswith(el.info, "jldoctest")
-        push!(set, crc32c(el.code))
-    elseif el isa Documenter.DocsNode
-        # Docstring content lives in a side tree, not the node's own children.
-        for md in el.mdasts
-            scan_jldoctests!(set, md)
+    if el isa Documenter.MetaNode
+        # Both `@meta` snapshots and our `@codeblocks` nodes land here.
+        state = BlockMeta(
+            get(el.dict, :CurrentModule, state.mod),
+            get(el.dict, _LINE_COUNTER_KEY, state.line_counter),
+        )
+    elseif el isa Documenter.MarkdownAST.CodeBlock
+        kind = _block_kind(el)
+        if kind !== nothing
+            startswith(el.info, "jldoctest") && push!(plugin.jldoctests, crc32c(el.code))
+            meta = BlockMeta(state.mod, state.line_counter, _fence_name(el.info))
+            _record_blockmeta!(plugin, pagekey, kind, crc32c(el.code), meta)
         end
+    elseif el isa Documenter.MultiCodeBlock
+        # An executed `@repl` block: the segments are CodeBlock children —
+        # julia-repl inputs (prompt included, matching the rendered source)
+        # and documenter-ansi outputs. Key it by the first input; a multiblock
+        # without one is left untouched by the post-render pass, so it is not
+        # recorded here either. The series name lives on the original fence
+        # (`@repl name`), retained in `el.codeblock`. Do NOT descend: the
+        # segments render as one block, not as individual julia-repl blocks.
+        for child in node.children
+            c = child.element
+            if c isa Documenter.MarkdownAST.CodeBlock && startswith(c.info, "julia-repl")
+                meta = BlockMeta(state.mod, state.line_counter, _fence_name(el.codeblock.info))
+                _record_blockmeta!(plugin, pagekey, :multi, crc32c(c.code), meta)
+                break
+            end
+        end
+        return state
+    elseif el isa Documenter.MultiOutput
+        # An executed `@example` block: the rendered input is a plain-fence
+        # CodeBlock child, so the series name (`@example name`) lives on the
+        # original fence retained in `el.codeblock`. Other children are output
+        # elements — recursed generically, since rendered markdown output can
+        # itself embed code blocks (those carry no series name).
+        name = _fence_name(el.codeblock.info)
+        for child in node.children
+            c = child.element
+            if c isa Documenter.MarkdownAST.CodeBlock && (kind = _block_kind(c)) !== nothing
+                meta = BlockMeta(state.mod, state.line_counter, name)
+                _record_blockmeta!(plugin, pagekey, kind, crc32c(c.code), meta)
+            else
+                scan_page!(plugin, pagekey, child, state)
+            end
+        end
+        return state
+    elseif el isa Documenter.DocsNode
+        # A docstring is its own page: blocks in it resolve in the docstring's
+        # own module and always number from 1 (its content lives in side
+        # trees, not the node's children).
+        for (md, meta) in zip(el.mdasts, el.metas)
+            scan_page!(plugin, pagekey, md, BlockMeta(get(meta, :module, state.mod), :restart))
+        end
+        return state
+    elseif el isa Documenter.EvalNode
+        # Rendered `@eval` output; its meta (if any) stays local like
+        # Documenter's own walkers, which never descend into it.
+        el.result === nothing || scan_page!(plugin, pagekey, el.result, state)
+        return state
     end
     for child in node.children
-        scan_jldoctests!(set, child)
+        state = scan_page!(plugin, pagekey, child, state)
     end
-    return
+    return state
+end
+
+# The recorded meta for the next occurrence of this block on the page, in
+# document order, or `nothing` when the scan did not see it (fall back to the
+# page-final state — the pre-scan behavior).
+function _consume_blockmeta!(plugin, doc, page, kind, source)
+    page === nothing && return nothing
+    pagedict = get(plugin.blockmeta, page_key(doc, page), nothing)
+    pagedict === nothing && return nothing
+    q = get(pagedict, (kind, crc32c(source)), nothing)
+    (q === nothing || isempty(q)) && return nothing
+    return popfirst!(q)
 end
 
 # Matches a Julia code block emitted by Documenter's HTML writer. The ` hljs`
@@ -163,52 +339,92 @@ function _enclosing_docstring_ids(html, offset)
     return ids
 end
 
+# The recovered source of the first julia-repl input of a MultiCodeBlock
+# <pre>, or `nothing` when there is none (not an `@repl` block — some other
+# language's multiblock, left untouched). Doubles as the block's scan key.
+function _first_repl_source(inner)
+    for m in eachmatch(MULTIREPL_SEG_RE, inner)
+        m.captures[1] !== nothing && startswith(m.captures[1], "language-julia-repl") &&
+            return block_source(m.captures[2])
+    end
+    return nothing
+end
+
 function process_html(html::AbstractString, plugin::CodeBlocks, doc, page)
     seen = Dict{String, Int}()
     # Unique reference targets used on this page (href => target info), collected
     # by the resolver while blocks are processed; becomes the page's hidden
     # tooltip payload (doxygen-style, deduplicated per page).
     tips = Dict{String, Any}()
-    # Manual scan (not `replace`) so each match can see its context: a block
-    # directly after `<section><div>` is a docstring's signature header, and a
-    # block inside a docstring suppresses self references.
+    # One pass over all three block shapes in document order (their <pre> forms
+    # are mutually exclusive, so the matches cannot overlap) — the running line
+    # counter for `line_counter = :continue` must see the page's blocks in
+    # order regardless of kind. Manual emission (not `replace`) so each match
+    # can see its context: a block directly after `<section><div>` is a
+    # docstring's signature header, and a block inside a docstring suppresses
+    # self references.
+    matches = sort!(
+        vcat(
+            [(m, :block) for m in eachmatch(BLOCK_RE, html)],
+            [(m, :repl) for m in eachmatch(REPL_RE, html)],
+            [(m, :multi) for m in eachmatch(MULTIREPL_RE, html)],
+        ); by = t -> t[1].offset,
+    )
     io = IOBuffer()
     pos = 1
-    for m in eachmatch(BLOCK_RE, html)
+    counter = 0   # last displayed line number of the page's processed blocks
+    named = Dict{String, Int}()   # per-series counters for `line_counter = :named`
+    for (m, kind) in matches
         print(io, SubString(html, pos, prevind(html, m.offset)))
-        content = String(m.captures[2])
+        pos = m.offset + ncodeunits(m.match)
         self_ids = _enclosing_docstring_ids(html, m.offset)
-        if _docstring_sig_prefix(html, m.offset)
-            print(io, transform_signature_block(content, plugin, doc, page, tips, self_ids))
+        if kind === :multi
+            source = _first_repl_source(m.captures[1])
+            if source === nothing   # not an `@repl` block: leave untouched
+                print(io, m.match)
+                continue
+            end
         else
-            print(io, transform_block(content, plugin, doc, page, seen, tips, self_ids))
+            source = block_source(m.captures[2])
         end
-        pos = m.offset + ncodeunits(m.match)
-    end
-    print(io, SubString(html, pos))
-    html = String(take!(io))
-    # REPL transcripts are highlighted too (so runtime hljs isn't needed at all).
-    io = IOBuffer()
-    pos = 1
-    for m in eachmatch(REPL_RE, html)
-        print(io, SubString(html, pos, prevind(html, m.offset)))
-        self_ids = _enclosing_docstring_ids(html, m.offset)
-        print(io, transform_repl_block(String(m.captures[2]), plugin, doc, page, seen, tips, self_ids))
-        pos = m.offset + ncodeunits(m.match)
-    end
-    print(io, SubString(html, pos))
-    html = String(take!(io))
-    # `@repl` blocks (MultiCodeBlock pres) are rebuilt into the same transcript
-    # form. A multiblock with no julia-repl input is not an `@repl` block and is
-    # left untouched (transform returns nothing).
-    io = IOBuffer()
-    pos = 1
-    for m in eachmatch(MULTIREPL_RE, html)
-        print(io, SubString(html, pos, prevind(html, m.offset)))
-        self_ids = _enclosing_docstring_ids(html, m.offset)
-        new = transform_multirepl_block(m.captures[1], plugin, doc, page, seen, tips, self_ids)
-        print(io, new === nothing ? m.match : new)
-        pos = m.offset + ncodeunits(m.match)
+        meta = _consume_blockmeta!(plugin, doc, page, kind, source)
+        mod = meta === nothing ? nothing : meta.mod
+        if kind === :block && _docstring_sig_prefix(html, m.offset)
+            # Signature headers have no gutter: no counter interaction.
+            print(io, transform_signature_block(source, plugin, doc, page, tips, self_ids, mod))
+            continue
+        end
+        # A block inside a docstring is its own page: it numbers from 1 and
+        # does not advance the page counter (the scan records docstring blocks
+        # with :restart, so `meta` agrees). In :named mode each named
+        # series has its own counter; unnamed blocks restart.
+        docstring = self_ids !== nothing
+        start = if meta === nothing || docstring
+            1
+        elseif meta.line_counter === :continue
+            counter + 1
+        elseif meta.line_counter === :named && meta.name !== nothing
+            get(named, meta.name, 0) + 1
+        else
+            1
+        end
+        block_html, nlines = if kind === :block
+            transform_block(source, plugin, doc, page, seen, tips, self_ids, mod, start)
+        elseif kind === :repl
+            transform_repl_block(source, plugin, doc, page, seen, tips, self_ids, mod, start)
+        else
+            transform_multirepl_block(m.captures[1], plugin, doc, page, seen, tips, self_ids, mod, start)
+        end
+        # Every processed page block advances the page counter — restart
+        # blocks too, so a later `continue` block picks up from the last
+        # number the reader saw — gutter or not (`min_lines` gaps would break
+        # continuity). A named block likewise advances its series counter.
+        if !docstring
+            counter = start + nlines - 1
+            meta !== nothing && meta.name !== nothing &&
+                (named[meta.name] = start + nlines - 1)
+        end
+        print(io, block_html)
     end
     print(io, SubString(html, pos))
     html = String(take!(io))
@@ -225,9 +441,8 @@ end
 # (`binding = true`), so parameter names bind and stay plain while type
 # positions and the `-> T` return type link; the documented name itself is a
 # (candidate-aware) self reference and never links.
-function transform_signature_block(content, plugin, doc, page, tips = nothing, self_ids = nothing)
-    source = block_source(content)
-    resolve = make_resolver(plugin, doc, page, tips, self_ids)
+function transform_signature_block(source, plugin, doc, page, tips = nothing, self_ids = nothing, mod = nothing)
+    resolve = make_resolver(plugin, doc, page, tips, self_ids, mod)
     return string(
         "<pre><code class=\"", CODE_CLASSES, "\">",
         highlight_julia_html(source; resolve = resolve, binding = true),
@@ -235,37 +450,39 @@ function transform_signature_block(content, plugin, doc, page, tips = nothing, s
     )
 end
 
-function transform_block(content, plugin, doc, page, seen, tips, self_ids = nothing)
-    source = block_source(content)
+# The block transforms take the positional per-block meta — `mod`, the module
+# references resolve in, and `start`, the first displayed line number
+# (`> 1` under `line_counter = :continue`) — and return `(html, nlines)` so
+# the caller can advance the page's running line counter.
+function transform_block(source, plugin, doc, page, seen, tips, self_ids = nothing, mod = nothing, start = 1)
     id = block_id(source, seen)
 
     # Only a real `jldoctest` block gets the script-style `# output` split.
     jldoctest = crc32c(source) in plugin.jldoctests
     line_htmls = highlight_julia_lines(
         source, plugin, doc, page;
-        jldoctest = jldoctest, tips = tips, self_ids = self_ids,
+        jldoctest = jldoctest, tips = tips, self_ids = self_ids, mod = mod,
     )
 
     if !plugin.line_numbers || length(line_htmls) < plugin.min_lines
         # No gutter (line_numbers disabled, or a one-liner), but keep the
         # highlighted content and the block id + permalink.
-        return plain_pre(id, CODE_CLASSES, join(line_htmls, "\n"))
+        return plain_pre(id, CODE_CLASSES, join(line_htmls, "\n")), length(line_htmls)
     end
-    return numbered_pre(id, CODE_CLASSES, line_htmls)
+    return numbered_pre(id, CODE_CLASSES, line_htmls, start), length(line_htmls)
 end
 
 # REPL transcripts (julia-repl blocks and REPL-style jldoctests) are numbered
 # too by default — linkable lines are just as useful in a transcript — but it
 # has its own toggle (`repl_line_numbers`) on top of `line_numbers`.
-function transform_repl_block(content, plugin, doc, page, seen, tips, self_ids = nothing)
-    source = block_source(content)
+function transform_repl_block(source, plugin, doc, page, seen, tips, self_ids = nothing, mod = nothing, start = 1)
     id = block_id(source, seen)
-    html = highlight_repl_html(source; resolve = make_resolver(plugin, doc, page, tips, self_ids))
-    if plugin.line_numbers && plugin.repl_line_numbers
-        line_htmls = split_highlighted(html)
-        length(line_htmls) >= plugin.min_lines && return numbered_pre(id, CODE_CLASSES, line_htmls)
+    html = highlight_repl_html(source; resolve = make_resolver(plugin, doc, page, tips, self_ids, mod))
+    line_htmls = split_highlighted(html)
+    if plugin.line_numbers && plugin.repl_line_numbers && length(line_htmls) >= plugin.min_lines
+        return numbered_pre(id, CODE_CLASSES, line_htmls, start), length(line_htmls)
     end
-    return plain_pre(id, CODE_CLASSES, html)
+    return plain_pre(id, CODE_CLASSES, html), length(line_htmls)
 end
 
 # Rebuild an `@repl` MultiCodeBlock <pre> as one transcript block: input
@@ -274,13 +491,12 @@ end
 # segments keep their inner HTML verbatim, re-wrapped in `<span class="ansi">`
 # so the themes' `.ansi span.sgrNN` color rules still apply after the original
 # `<code class="… ansi">` wrapper is gone; the <br/> Documenter puts between
-# iterations becomes the transcript's blank line. Returns nothing when no
-# segment is julia-repl input (some other language's multiblock).
-function transform_multirepl_block(inner, plugin, doc, page, seen, tips, self_ids = nothing)
+# iterations becomes the transcript's blank line. The caller has already
+# checked for a julia-repl input (`_first_repl_source`).
+function transform_multirepl_block(inner, plugin, doc, page, seen, tips, self_ids = nothing, mod = nothing, start = 1)
     segments = collect(eachmatch(MULTIREPL_SEG_RE, inner))
     isrepl(m) = m.captures[1] !== nothing && startswith(m.captures[1], "language-julia-repl")
-    any(isrepl, segments) || return nothing
-    resolve = make_resolver(plugin, doc, page, tips, self_ids)
+    resolve = make_resolver(plugin, doc, page, tips, self_ids, mod)
     htmls = String[]
     sources = String[]
     for m in segments
@@ -299,9 +515,9 @@ function transform_multirepl_block(inner, plugin, doc, page, seen, tips, self_id
     end
     id = block_id(join(sources, "\n"), seen)
     html = join(htmls, "\n")
-    if plugin.line_numbers && plugin.repl_line_numbers
-        line_htmls = split_highlighted(html)
-        length(line_htmls) >= plugin.min_lines && return numbered_pre(id, CODE_CLASSES, line_htmls)
+    line_htmls = split_highlighted(html)
+    if plugin.line_numbers && plugin.repl_line_numbers && length(line_htmls) >= plugin.min_lines
+        return numbered_pre(id, CODE_CLASSES, line_htmls, start), length(line_htmls)
     end
-    return plain_pre(id, CODE_CLASSES, html)
+    return plain_pre(id, CODE_CLASSES, html), length(line_htmls)
 end

--- a/src/references.jl
+++ b/src/references.jl
@@ -42,9 +42,12 @@ end
 # documented objects for the binding when the reference is ambiguous (neither the
 # exact typesig nor the dispatch probe singled one out). The targets feed the
 # doxygen-style hover tooltips (signature list + per-page tip payloads).
-function resolve_reference(name::AbstractString, doc, page, arity = nothing, plugin = nothing)
+# `mod` is the module the block resolves in — its positional `CurrentModule`
+# (or the docstring's own module), from the ScanStep; `nothing` falls back to
+# the page-final state (blocks the scan did not see).
+function resolve_reference(name::AbstractString, doc, page, arity = nothing, plugin = nothing, mod = nothing)
     page === nothing && return nothing
-    mod = get(page.globals.meta, :CurrentModule, Main)
+    mod === nothing && (mod = get(page.globals.meta, :CurrentModule, Main))
 
     # Parse the identifier; accept a bare symbol, a dotted path (Foo.bar), or a
     # macro name (`@time`, `Foo.@bar`, `@raw_str`) — the latter parses as a

--- a/src/render.jl
+++ b/src/render.jl
@@ -37,9 +37,20 @@ function block_id(source::AbstractString, seen::Dict{String, Int})
 end
 
 # Build the `<span class="code-lines">…</span>` inner from per-line HTML fragments.
-function code_lines_html(line_htmls::Vector{String})
+# A `start > 1` (continued line_counter, `@codeblocks line_counter = :continue`)
+# offsets the CSS line counter via an inline `counter-reset` — inline style wins
+# over the stylesheet's `counter-reset: line` — and exposes the start to
+# line-numbers.js as `data-ln-start` (fragment L-numbers are displayed numbers).
+function code_lines_html(line_htmls::Vector{String}, start::Int = 1)
     io = IOBuffer()
-    print(io, "<span class=\"code-lines\">")
+    if start == 1
+        print(io, "<span class=\"code-lines\">")
+    else
+        print(
+            io, "<span class=\"code-lines\" data-ln-start=\"", start,
+            "\" style=\"counter-reset: line ", start - 1, "\">",
+        )
+    end
     for frag in line_htmls
         print(io, "<span class=\"line\"><span class=\"line-num\" aria-hidden=\"true\"></span>", frag, "</span>")
     end
@@ -47,13 +58,14 @@ function code_lines_html(line_htmls::Vector{String})
     return String(take!(io))
 end
 
-# Full replacement <pre> for a multi-line (numbered) block.
-function numbered_pre(id::AbstractString, code_classes::AbstractString, line_htmls::Vector{String})
-    digits = length(string(length(line_htmls)))
+# Full replacement <pre> for a multi-line (numbered) block. With `start == 1`
+# (the default, restart mode) the markup is exactly as before.
+function numbered_pre(id::AbstractString, code_classes::AbstractString, line_htmls::Vector{String}, start::Int = 1)
+    digits = length(string(start + length(line_htmls) - 1))
     style = digits > 2 ? " style=\"--ln-digits:$(digits)\"" : ""
     return string(
         "<pre id=\"", id, "\"><code class=\"", code_classes, " line-numbers\"", style, ">",
-        code_lines_html(line_htmls),
+        code_lines_html(line_htmls, start),
         "</code></pre>",
     )
 end

--- a/test/docsite/demo.jl
+++ b/test/docsite/demo.jl
@@ -354,3 +354,49 @@ Return `text` unchanged. A documented **string macro**: the `w` prefix of a
 macro w_str(s)
     return s
 end
+
+# ---------------------------------------------------------------------------
+# Positional-meta testbed (continued.md): a second module for `CurrentModule`
+# switching, and a function documented on the continued page itself.
+# ---------------------------------------------------------------------------
+
+module DemoInner
+
+    """
+        inner_fn(x)
+
+    Return `x` doubled. Documented inside the submodule `DemoInner`: unqualified
+    references resolve here only where `CurrentModule = DocumenterCodeBlocks.DemoInner`
+    is in effect — positionally, exactly like `@ref`. This docstring's example
+    block resolves in `DemoInner` regardless of the page's `CurrentModule`:
+
+    ```julia
+    y = inner_helper(inner_fn(2))
+    ```
+    """
+    inner_fn(x) = 2x
+
+    """
+        inner_helper(x)
+
+    Return `x` unchanged. A second documented name in `DemoInner`, referenced
+    unqualified from `inner_fn`'s docstring example.
+    """
+    inner_helper(x) = x
+
+end # module DemoInner
+
+"""
+    stepwise(v)
+
+Return `v`. Documented (with `@docs`) on the *continued* page to verify that
+docstring code blocks are their own page: they restart their line numbers at 1
+and do not advance the page's running counter — while the docstring's example
+still gets links (`add_numbers` below):
+
+```julia
+a = stepwise([1, 2])
+b = add_numbers(a[1], a[2])
+```
+"""
+stepwise(v) = v

--- a/test/docsite/make.jl
+++ b/test/docsite/make.jl
@@ -48,5 +48,6 @@ makedocs(
         "Skip cases" => "skipcases.md",
         "Reference links" => "references.md",
         "Doctest blocks" => "doctest-blocks.md",
+        "Continued numbering" => "continued.md",
     ],
 )

--- a/test/docsite/src/continued.md
+++ b/test/docsite/src/continued.md
@@ -1,0 +1,161 @@
+```@meta
+CurrentModule = DocumenterCodeBlocks
+```
+
+# Continued numbering & positional meta
+
+This page exercises the `@codeblocks` options block and positional metadata:
+one running line counter across blocks (`line_counter = :continue`), flipping
+back to `:restart` mid-page, an `@meta CurrentModule` switch that applies
+from its position on, and a `@docs` entry proving docstrings are their own
+page.
+
+```@codeblocks
+line_counter = :continue
+```
+
+The first block numbers 1–4 as usual (`greet` and `add_numbers` resolve in
+`DocumenterCodeBlocks`, the page's `CurrentModule` here; `inner_fn` must NOT
+resolve yet):
+
+```julia
+greet()
+x = add_numbers(1, 2)
+y = inner_fn  # not in scope here: no link
+z = x + 1
+```
+
+A REPL transcript continues at line 5:
+
+```julia-repl
+julia> add_numbers(20, 22)
+42
+```
+
+An executed `@repl` block continues at line 7:
+
+```@repl
+import DocumenterCodeBlocks
+DocumenterCodeBlocks.add_numbers(2, 3)
+```
+
+A one-liner also continues (line 11) and advances the counter:
+
+```julia
+greet()
+```
+
+## Docstrings are their own page
+
+The docstring below sits in the middle of the continued sequence. Its example
+block starts at 1 (no `data-ln-start`) and does not advance the page counter:
+
+```@docs
+DocumenterCodeBlocks.stepwise
+```
+
+The next page block therefore continues at line 12:
+
+```julia
+a = greet()
+b = add_numbers(1, 1)
+```
+
+## Switching the module mid-page
+
+```@meta
+CurrentModule = DocumenterCodeBlocks.DemoInner
+```
+
+From here on unqualified names resolve in `DemoInner` — `inner_fn` links now,
+while `add_numbers` (defined in the parent module) no longer resolves
+unqualified. Numbering still continues (line 14):
+
+```julia
+v = inner_fn(21)
+w = inner_helper(v)
+u = add_numbers  # not in scope here: no link
+```
+
+## Back to restarting
+
+```@codeblocks
+line_counter = :restart
+```
+
+After flipping back, this block starts at 1 again:
+
+```julia
+p = inner_fn(1)
+q = inner_helper(p)
+```
+
+A longer restart block (exercises gutter selection on this page too):
+
+```julia
+function walkthrough(v)
+    s = zero(eltype(v))
+    for x in v
+        s = inner_fn(s) + x
+    end
+    if isempty(v)
+        s = -1
+    end
+    return s
+end
+```
+
+## Named series
+
+```@codeblocks
+line_counter = :named
+```
+
+Under `line_counter = :named` each **named series** carries its own counter,
+mixing block kinds; unnamed blocks restart. The `@example series-a` pair
+below continues 1–2 → 3–4 across the unrelated blocks between them, and the
+named `jldoctest` pair continues 1–2 → 3–4 independently:
+
+```@example series-a
+a1 = 1 + 1
+a2 = a1 + 1
+nothing # hide
+```
+
+An unnamed block in named mode restarts (and touches no series):
+
+```julia
+t = inner_helper(3)
+```
+
+A different name is a different series (starts at 1):
+
+```@example series-b
+b1 = 10
+nothing # hide
+```
+
+```@example series-a
+a3 = a2 + 1
+nothing # hide
+```
+
+```jldoctest counter-demo
+julia> x = 20 + 1
+21
+```
+
+```jldoctest counter-demo
+julia> x + 21
+42
+```
+
+## DemoInner API
+
+The docstrings for the `DemoInner` demo module (referenced unqualified above,
+under the switched `CurrentModule`):
+
+```@docs
+inner_fn
+inner_helper
+```

--- a/test/docsite/src/index.md
+++ b/test/docsite/src/index.md
@@ -16,6 +16,8 @@ site's build output.
 - [Skip cases](@ref) — `julia-repl`, `@example` output, and `nohighlight`
   blocks that must be left untouched.
 - [Reference links](@ref) — identifiers that resolve to docstrings.
+- [Continued numbering & positional meta](@ref) — `@codeblocks` options and
+  positional `CurrentModule`.
 
 ## API
 

--- a/test/playwright/verify.js
+++ b/test/playwright/verify.js
@@ -260,6 +260,67 @@ function check(name, ok, detail) {
   }
   await page3.close();
 
+  // ---- continued numbering (data-ln-start offsets), when present ---------
+  // Only pages using `@codeblocks line_counter = :continue` have offset
+  // blocks; on other pages this section reports itself skipped.
+  const contBlocks = await page.evaluate(() =>
+    Array.from(document.querySelectorAll(".code-lines[data-ln-start]")).map((w) => {
+      const pre = w.closest("pre");
+      // (getComputedStyle content returns the literal `counter(line)` —
+      // browsers don't resolve counters there — so check the inline
+      // counter-reset the digits render from instead.)
+      const m = /line\s+(\d+)/.exec(w.style.counterReset || "");
+      return {
+        id: pre.id,
+        start: parseInt(w.dataset.lnStart, 10),
+        lines: w.querySelectorAll(".line").length,
+        reset: m ? parseInt(m[1], 10) : null,
+      };
+    })
+  );
+  if (contBlocks.length === 0) {
+    check("continued numbering (skipped: no data-ln-start blocks on page)", true);
+  } else {
+    // The CSS counter offset matches the declared start: the first gutter
+    // digit renders as `reset + 1` == start.
+    check(
+      "continued blocks carry a matching counter offset",
+      contBlocks.every((b) => b.reset === b.start - 1),
+      JSON.stringify(contBlocks.map((b) => [b.start, b.reset]))
+    );
+    // Gutter click on a continued block puts the DISPLAYED number in the hash.
+    const cb = contBlocks[0];
+    await page.evaluate(() => history.replaceState(null, "", location.pathname));
+    const cell = page.locator(`#${cb.id} .line .line-num`).first();
+    await cell.click();
+    const hash1 = await page.evaluate(() => location.hash);
+    check(
+      "gutter click uses displayed numbers in the hash",
+      hash1 === `#${cb.id}-L${cb.start}`,
+      `${hash1} (expected #${cb.id}-L${cb.start})`
+    );
+    // Hash restore maps the displayed number back to the right child line.
+    const lastDisplayed = cb.start + cb.lines - 1;
+    const hl = await page.evaluate(
+      ([id, disp]) => {
+        history.replaceState(null, "", `#${id}-L${disp}`);
+        window.dispatchEvent(new HashChangeEvent("hashchange"));
+        const lines = document.querySelectorAll(`#${id} .line`);
+        return {
+          hlIndex: Array.from(lines).findIndex((l) => l.classList.contains("hl")),
+          hlCount: document.querySelectorAll(`#${id} .line.hl`).length,
+        };
+      },
+      [cb.id, lastDisplayed]
+    );
+    check(
+      "hash restore highlights the offset-mapped line",
+      hl.hlCount === 1 && hl.hlIndex === cb.lines - 1,
+      JSON.stringify(hl)
+    );
+    await page.evaluate(() => history.replaceState(null, "", location.pathname));
+  }
+
   // ---- theme sweep: gutter bg must equal pre bg in all six themes ----
   const themes = ["documenter-light", "documenter-dark", "catppuccin-latte",
     "catppuccin-frappe", "catppuccin-macchiato", "catppuccin-mocha"];

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,76 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
         @test startswith(id1, "c-")
         @test DCB.block_id("x = 1", seen) == id1 * "-2"   # same-page duplicate
         @test DCB.block_id("x = 2", seen) != id1
+        # Continued numbering: start > 1 offsets the CSS counter inline and
+        # exposes the start to line-numbers.js; start == 1 (restart, the
+        # default) emits exactly the pre-offset markup.
+        offset = DCB.numbered_pre("c-x", "k", ["a", "b"], 5)
+        @test occursin("data-ln-start=\"5\"", offset)
+        @test occursin("style=\"counter-reset: line 4\"", offset)
+        @test !occursin("data-ln-start", DCB.numbered_pre("c-x", "k", ["a", "b"]))
+        # The gutter width fits the LAST displayed number.
+        @test occursin("--ln-digits:3", DCB.numbered_pre("c-x", "k", ["a", "b"], 99))
+    end
+
+    @testset "global line_counter option" begin
+        # Constructor validation: Symbols only, restricted vocabulary.
+        @test CodeBlocks().line_counter === :restart
+        @test CodeBlocks(line_counter = :continue).line_counter === :continue
+        @test CodeBlocks(line_counter = :named).line_counter === :named
+        @test_throws ArgumentError CodeBlocks(line_counter = :sideways)
+        @test_throws ArgumentError CodeBlocks(line_counter = "continue")
+        # The global default applies to every page (here: two blocks continue
+        # 1–2 → 3), and an `@codeblocks` block still overrides it
+        # positionally (the third block restarts).
+        mktempdir() do dir
+            mkpath(joinpath(dir, "src"))
+            write(
+                joinpath(dir, "src", "index.md"), """
+                # T
+
+                ```julia
+                a = 1
+                b = 2
+                ```
+
+                ```julia
+                c = 3
+                ```
+
+                ```@codeblocks
+                line_counter = :restart
+                ```
+
+                ```julia
+                d = 4
+                ```
+                """
+            )
+            Logging.with_logger(Logging.NullLogger()) do
+                Documenter.makedocs(
+                    root = dir, sitename = "t", remotes = nothing,
+                    plugins = [CodeBlocks(line_counter = :continue)],
+                    format = Documenter.HTML(edit_link = nothing, inventory_version = "0"),
+                )
+            end
+            html = read(joinpath(dir, "build", "index.html"), String)
+            @test [m.captures[1] for m in eachmatch(r"data-ln-start=\"(\d+)\"", html)] == ["3"]
+        end
+    end
+
+    @testset "scan block kinds" begin
+        # The scan must classify fences exactly like the rendered HTML the
+        # post-render passes will consume: jldoctests render as julia-repl
+        # iff they contain a prompt (Documenter's fence-first rule).
+        kind(info, code = "x") = DCB._block_kind(Documenter.MarkdownAST.CodeBlock(info, code))
+        @test kind("julia") === :block
+        @test kind("julia-repl") === :repl
+        @test kind("jldoctest") === :block                       # script style
+        @test kind("jldoctest", "julia> 1\n1") === :repl         # REPL style
+        @test kind("jldoctest label; filter = r\"x\"") === :block
+        @test kind("text") === nothing
+        @test kind("nohighlight") === nothing
+        @test kind("") === nothing
     end
 
     @testset "arity" begin
@@ -260,6 +330,7 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
         index = read(joinpath(build, "index.html"), String)
         skip = read(joinpath(build, "skipcases", "index.html"), String)
         doct = read(joinpath(build, "doctest-blocks", "index.html"), String)
+        cont = read(joinpath(build, "continued", "index.html"), String)
 
         link_hrefs(html, frag) = [
             m.captures[1] for m in eachmatch(r"<a class=\"julia-ref\" href=\"([^\"]*)\"", html)
@@ -443,6 +514,83 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
             # REPL transcripts get gutters and highlighted prompts/input.
             @test occursin("julia-prompt", skip)
             @test occursin(r"line-numbers[^>]*>.{0,200}julia-prompt"s, skip)
+        end
+
+        @testset "@codeblocks continued numbering" begin
+            # One running counter in document order, across block kinds:
+            # julia 1–4 → repl 5–6 → @repl 7–10 → one-liner 11 → (docstring)
+            # → 12–13 → 14–16 → restart back to 1; then the named-series
+            # section (its two continuing blocks start at 3 each). Only
+            # offset blocks carry the attribute; the sequence pins both the
+            # offsets and the fact that the docstring in the middle does not
+            # advance the counter.
+            @test [m.captures[1] for m in eachmatch(r"data-ln-start=\"(\d+)\"", cont)] ==
+                ["5", "7", "11", "12", "14", "3", "3"]
+            # The inline style offsets the CSS counter next to the attribute.
+            @test occursin(
+                "<span class=\"code-lines\" data-ln-start=\"5\" style=\"counter-reset: line 4\">",
+                cont,
+            )
+            # The executed @repl block participates in the continuation.
+            @test occursin(r"data-ln-start=\"7\"[^>]*>.{0,400}julia-prompt"s, cont)
+            # Default mode is untouched: no other page carries offset markup.
+            for html in (index, refs, zoo, skip, doct)
+                @test !occursin("data-ln-start", html)
+                @test !occursin("counter-reset", html)
+            end
+            # The docstring on the page is its own page: its example block has
+            # no offset markup, but still gets reference links (and self
+            # suppression for stepwise itself).
+            stepdoc = docstring_details(cont, "DocumenterCodeBlocks.stepwise")
+            @test !occursin("data-ln-start", stepdoc)
+            @test occursin(r"julia-ref\" href=\"[^\"]*add_numbers\"", stepdoc)
+            @test !occursin("stepwise</span></a>", stepdoc)
+            # line_counter = :named: the @example series-a pair continues
+            # 1–2 → 3 across unrelated blocks (the second block is the
+            # one-liner `a3 = a2 + 1`), and the named REPL-style jldoctest
+            # pair continues 1–2 → 3–4 independently. Unnamed blocks and
+            # other series in between restart (no data-ln-start).
+            @test occursin(
+                r"data-ln-start=\"3\"[^>]*style=\"counter-reset: line 2\"[^>]*>.{0,300}a3",
+                cont,
+            )
+            @test occursin(r"data-ln-start=\"3\"[^>]*>.{0,300}julia-prompt"s, cont)
+            # The series-b block (different name) starts a fresh series: no
+            # offset markup on its enclosing <pre>.
+            ib1 = findfirst(">b1 ", cont)
+            @test ib1 !== nothing
+            b1block = SubString(
+                cont, first(findprev("<pre", cont, first(ib1))),
+                last(findnext("</pre>", cont, first(ib1))),
+            )
+            @test !occursin("data-ln-start", b1block)
+        end
+
+        @testset "positional CurrentModule" begin
+            # Before the mid-page switch, unqualified DemoInner names must not
+            # resolve; after it they do — and the parent module's names stop
+            # resolving unqualified. Both value mentions stay plain text:
+            @test occursin(r"y <span class=\"julia-keyword\">=</span> inner_fn\b", cont)
+            @test occursin(r"u <span class=\"julia-keyword\">=</span> add_numbers\b", cont)
+            # inner_fn links from the switch block and the two restart blocks
+            # (its own docstring call is a self reference); inner_helper also
+            # links from the named-section block and inner_fn's docstring.
+            @test length(link_hrefs(cont, "DemoInner.inner_fn")) == 3
+            @test length(link_hrefs(cont, "DemoInner.inner_helper")) == 4
+            # The @repl block resolves its QUALIFIED reference even though the
+            # page-final CurrentModule is DemoInner (where the qualifier does
+            # not resolve): per-block meta, not page-final state.
+            @test occursin(
+                r"data-ln-start=\"7\"[^>]*>.{0,600}julia-ref\" href=\"[^\"]*add_numbers\""s,
+                cont,
+            )
+            # A docstring resolves in its own module wherever it lands:
+            # inner_fn's example links inner_helper via DemoInner.
+            innerdoc = docstring_details(cont, "DocumenterCodeBlocks.DemoInner.inner_fn")
+            @test occursin(
+                "julia-ref\" href=\"#DocumenterCodeBlocks.DemoInner.inner_helper\"",
+                innerdoc,
+            )
         end
 
         @testset "@repl blocks" begin


### PR DESCRIPTION
The plugin post-processes rendered HTML and read `page.globals.meta`
once -- the final merged state -- while Documenter applies `@meta`
positionally (crossref re-walks each page merging MetaNodes in document
order, and overrides CurrentModule with the docstring's own module
inside docstrings). Code-block reference links could therefore diverge
from `@ref` on pages that switch CurrentModule midway, and docstring
examples resolved in the page's module instead of their own.

A new ScanStep walk (absorbing the old jldoctest scan, order 4.5)
records the meta state at every code block's position, keyed by
(kind, source hash) with per-occurrence FIFO queues, and the post-render
step -- now a single pass over all block shapes in document order --
resolves each block in its recorded module. Docstrings are their own
page: their blocks resolve in the docstring's module.

On top of the positional machinery, a new `@codeblocks` block provides
page-local plugin options (Documenter warns on unknown `@meta` keys, so
the plugin brings its own meta-like block; it expands to a MetaNode,
which the writer renders as nothing). The first option is
`linenumbers`: "continue" carries one running line counter across the
page's julia/julia-repl/@repl blocks, tutorial style, instead of the
default "restart" numbering from 1. Continued blocks emit an inline CSS
counter offset plus data-ln-start, and line-numbers.js converts hash
L-numbers to child indices at the boundary, so line permalinks carry the
displayed numbers. Blocks inside docstrings always start at 1 and do not
advance the page counter. Default-mode markup is byte-identical.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
