### PR TITLE
External documentation links via DocumenterInterLinks inventories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.0] - Unreleased
+
+### Added
+ - External documentation links via
+   [DocumenterInterLinks](https://github.com/JuliaDocs/DocumenterInterLinks.jl):
+   when a name in a code block has no local docstring, it now falls back to
+   the inventories of an `InterLinks` plugin passed to `makedocs` — the same
+   inventories the `@extref` prose macro uses. The plugin is picked up
+   automatically from the Documenter build; nothing is configured on the
+   `CodeBlocks` side. External links carry the CSS class `julia-ref external`,
+   are marked with a small ↗ after the name, and their tooltip shows the
+   qualified name plus the project (and version) they link to. Qualified
+   names whose package is not loaded in the docs environment (`SomePkg.foo`)
+   are looked up verbatim. Opt out with `CodeBlocks(external_links = false)`.
+   DocumenterInterLinks and DocInventories are now (light) dependencies of
+   this package.
+
 ## [v1.3.0] - 2026-08-13
 
 ### Added
@@ -90,6 +107,7 @@ See [README.md](README.md) and the documentation for details.
 [v1.1.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.1.0
 [v1.2.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.2.0
 [v1.3.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.3.0
+[v1.4.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.4.0
 [#3]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/3
 [#5]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/5
 [#6]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/6

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,19 @@
 name = "DocumenterCodeBlocks"
 uuid = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Fredrik Ekre <ekrefredrik@gmail.com>"]
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
+DocInventories = "43dc2714-ed3b-44b5-b226-857eda1aa7de"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 
 [compat]
 CRC32c = "1"
+DocInventories = "0.4, 1"
 Documenter = "1.17"
+DocumenterInterLinks = "1"
 JuliaSyntax = "1"
 julia = "1.10"

--- a/assets/juliasyntax-tokens.css
+++ b/assets/juliasyntax-tokens.css
@@ -105,3 +105,12 @@ pre:hover code a.julia-ref {
   text-decoration-style: solid;
   text-decoration-color: currentColor;
 }
+
+/* External-documentation links (DocumenterInterLinks fallback): a small
+ * north-east arrow marks that the link leaves the site. */
+pre code a.julia-ref.external::after {
+  content: "\2197\FE0E";
+  font-size: 0.7em;
+  vertical-align: super;
+  opacity: 0.6;
+}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,10 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCodeBlocks = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 Documenter = "1.17"
+DocumenterInterLinks = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,6 @@
 using Documenter: Documenter, makedocs, deploydocs, DocMeta
 using DocumenterCodeBlocks
+using DocumenterInterLinks: InterLinks
 
 # The demo API the manual demonstrates reference links/tooltips against is
 # evaluated INTO the DocumenterCodeBlocks module — nothing ships with the
@@ -36,6 +37,12 @@ makedocs(
     modules = [DocumenterCodeBlocks],
     plugins = [
         CodeBlocks(),
+        # Demonstrates the external-link fallback in references.md: names
+        # without a local docstring link out via these inventories.
+        InterLinks(
+            "Julia" => "https://docs.julialang.org/en/v1/",
+            "Documenter" => "https://documenter.juliadocs.org/stable/",
+        ),
     ],
     pages = [
         "Home" => "index.md",

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -118,9 +118,50 @@ P = process(rand(3, 3), ones(3))   # arity 2 → the multi-line matrix signature
 t = transform([1, 2, 3], sqrt; rev = true)
 ```
 
+## External links
+
+Names that are not documented locally can still link — to **external
+documentation**. When an
+[DocumenterInterLinks](https://github.com/JuliaDocs/DocumenterInterLinks.jl)
+`InterLinks` plugin is passed to `makedocs`, its inventories (the same ones
+the `@extref` prose macro uses) become a fallback for code-block references:
+a block calling `sort` links to the Julia manual when a `Julia` inventory is
+configured. Nothing needs to be passed to `CodeBlocks` — the plugin is picked
+up automatically.
+
+External links are marked with a small ↗ after the name (CSS class
+`julia-ref external`), and their tooltip shows the qualified name plus the
+project (and version) the link goes to — inventories carry no docstring text,
+so there is no summary sentence.
+
+Some details:
+
+- Local docstrings always win; the inventories are only consulted when local
+  resolution fails.
+- Lookup uses the fully qualified name (`Base.sort`, `Base.@time`), resolved
+  through the same binding machinery as local references — so an unqualified
+  `sort` finds `Base.sort`. A qualified name whose package is not even loaded
+  in the docs environment (`SomePkg.foo`) is looked up verbatim.
+- Only `jl`-domain inventory entries match (functions, types, macros, …);
+  section labels and pages (`std` domain) never capture a code identifier.
+- Method entries in inventories carry signature suffixes; InterLinks' default
+  `alias_methods_as_function = true` adds the plain function names, which is
+  what code-block lookup relies on. Keep it enabled.
+
+Calls in this manual link out via the `Julia` and `Documenter` inventories,
+e.g.:
+
+```julia
+xs = sort([3, 1, 2])
+@show length(xs)
+Documenter.makedocs
+```
+
 ## Configuration
 
 - `reference_links = false` turns linking off entirely,
-- `popups = false` keeps the links but disables the tooltips.
+- `popups = false` keeps the links but disables the tooltips,
+- `external_links = false` keeps local links but disables the
+  inventory fallback.
 
-Both are keyword arguments of [`CodeBlocks`](@ref).
+All are keyword arguments of [`CodeBlocks`](@ref).

--- a/src/DocumenterCodeBlocks.jl
+++ b/src/DocumenterCodeBlocks.jl
@@ -20,7 +20,7 @@ end
 BlockMeta(mod::Module, line_counter::Symbol) = BlockMeta(mod, line_counter, nothing)
 
 """
-    CodeBlocks(; languages=["julia"], reference_links=true, popups=true, line_numbers=true, repl_line_numbers=true, min_lines=1, line_counter=:restart)
+    CodeBlocks(; languages=["julia"], reference_links=true, popups=true, external_links=true, line_numbers=true, repl_line_numbers=true, min_lines=1, line_counter=:restart)
 
 Documenter plugin that enhances code blocks with syntax highlighting, line
 numbers / linkable lines, and reference links — all in a single pass. Julia is
@@ -36,6 +36,12 @@ blocks), so no node/`prerender` is needed.
   When a reference matches several documented methods (a bare identifier, a
   splatted call, …) the tooltip instead lists all candidate signatures to pick
   from. Requires `reference_links=true`.
+- `external_links`: when a name is not documented locally and a
+  [DocumenterInterLinks](https://github.com/JuliaDocs/DocumenterInterLinks.jl)
+  `InterLinks` plugin is passed to `makedocs`, link it to the external
+  documentation (the same inventories `@extref` uses — no extra configuration
+  needed). External links are marked with a small ↗ and their tooltip names the
+  project they link to. Requires `reference_links=true`.
 - `line_numbers`: add the line-number gutter + linkable lines. When `false`, blocks
   are still highlighted (and linked) but rendered without a gutter.
 - `repl_line_numbers`: also add the gutter to REPL transcripts (`julia-repl`
@@ -88,6 +94,7 @@ struct CodeBlocks <: Documenter.Plugin
     languages::Vector{String}
     reference_links::Bool
     popups::Bool
+    external_links::Bool
     line_numbers::Bool
     repl_line_numbers::Bool
     min_lines::Int
@@ -108,8 +115,8 @@ struct CodeBlocks <: Documenter.Plugin
     warned::Set{String}
 end
 function CodeBlocks(;
-        languages = ["julia"], reference_links = true, popups = true, line_numbers = true,
-        repl_line_numbers = true, min_lines = 1, line_counter = :restart,
+        languages = ["julia"], reference_links = true, popups = true, external_links = true,
+        line_numbers = true, repl_line_numbers = true, min_lines = 1, line_counter = :restart,
     )
     line_counter isa Symbol && line_counter in (:restart, :continue, :named) || throw(
         ArgumentError(
@@ -118,8 +125,8 @@ function CodeBlocks(;
         ),
     )
     return CodeBlocks(
-        languages, reference_links, popups, line_numbers, repl_line_numbers, min_lines,
-        line_counter,
+        languages, reference_links, popups, external_links, line_numbers, repl_line_numbers,
+        min_lines, line_counter,
         Set{UInt32}(), Dict{String, Dict{Tuple{Symbol, UInt32}, Vector{BlockMeta}}}(),
         Set{String}(),
     )

--- a/src/juliasyntax.jl
+++ b/src/juliasyntax.jl
@@ -99,7 +99,8 @@ end
 # its variant tip via `data-ref-tip` — the href alone would find the shared,
 # un-narrowed payload.
 function _print_ref_open(io, ref)
-    print(io, "<a class=\"julia-ref\" href=\"", _escape_html(ref.href), "\"")
+    external = get(ref, :external, false) ? " external" : ""
+    print(io, "<a class=\"julia-ref", external, "\" href=\"", _escape_html(ref.href), "\"")
     if length(ref.targets) > 1
         print(io, " data-ref-targets=\"", _escape_html(_targets_json(ref.targets)), "\"")
     elseif (t = only(ref.targets)).tipkey != t.href

--- a/src/references.jl
+++ b/src/references.jl
@@ -9,6 +9,8 @@
 
 using Documenter: Documenter
 import Documenter.DocSystem
+using DocumenterInterLinks: InterLinks
+using DocInventories: DocInventories
 
 # `page.build` is the pre-prettyurl `.md` destination under doc.user.build, so its
 # path relative to the build dir is exactly the page key (e.g. "references.md").
@@ -64,9 +66,14 @@ function resolve_reference(name::AbstractString, doc, page, arity = nothing, plu
     binding = try
         DocSystem.binding(mod, ex)
     catch
-        return nothing
+        nothing
     end
-    binding === nothing && return nothing
+    if binding === nothing
+        # The module is not loaded in the docs environment; a qualified name can
+        # still be looked up verbatim in external inventories (their slugs are
+        # fully qualified, and macro spellings match: `Foo.@bar`, `Foo.@bar_str`).
+        return occursin(".", name) ? _external_reference(doc, plugin, name) : nothing
+    end
 
     # When the identifier is a call of known arity, ask for a method with that
     # many arguments (`Tuple{Any,…}`) so `foo(1, 2)` links to the `foo(a, b)`
@@ -80,9 +87,16 @@ function resolve_reference(name::AbstractString, doc, page, arity = nothing, plu
     object = try
         Documenter.find_object(doc, binding, typesig)
     catch
-        return nothing
+        nothing
     end
-    (object === nothing || !haskey(doc.internal.objects, object)) && return nothing
+    if object === nothing || !haskey(doc.internal.objects, object)
+        # Not documented locally → try external inventories under the same fully
+        # qualified slug Documenter uses ("Base.sort", "Base.@time", …). Bare
+        # undefined identifiers (loop temps, …) never reach the inventories, but
+        # a written-qualified name does even when currently undefined.
+        (Base.Docs.defined(binding) || occursin(".", name)) || return nothing
+        return _external_reference(doc, plugin, Documenter.bindingstring(binding))
+    end
 
     prettyurls = (fmt = findfirst_html(doc)) === nothing ? true : fmt.prettyurls
     from = _get_url(page_key(doc, page), prettyurls)
@@ -99,6 +113,60 @@ function resolve_reference(name::AbstractString, doc, page, arity = nothing, plu
         href = length(targets) == 1 ? only(targets).href :
             _object_href(doc, object, from, prettyurls),
         targets = targets,
+    )
+end
+
+# External-documentation fallback: when a name has no local docstring, look it
+# up in the inventories of the user's DocumenterInterLinks plugin (the same ones
+# `@extref` uses). The plugin is read from `doc.plugins` directly — the user
+# configures nothing here — and NOT via `Documenter.getplugin`, which would
+# construct (and cache) an empty `InterLinks` when none was passed to makedocs.
+# Returns `nothing` or the `resolve_reference` shape `(href, targets)` plus
+# `external = true`; the single target reuses the `_target_info` tuple shape so
+# the tooltip machinery works unchanged (no docstring text exists in
+# inventories, so the brief just names the linked project).
+function _external_reference(doc, plugin, slug::AbstractString)
+    plugin !== nothing && !plugin.external_links && return nothing
+    links = get(doc.plugins, InterLinks, nothing)
+    links === nothing && return nothing
+    hit = _interlinks_lookup(links, slug)
+    hit === nothing && return nothing
+    t = (
+        href = hit.href, tipkey = hit.href, label = hit.label, sig = hit.label,
+        brief = "External documentation ($(hit.project)).",
+    )
+    return (href = hit.href, targets = [t], external = true)
+end
+
+# Look `slug` up across the InterLinks inventories: the inventory named after
+# the slug's leading component first (mirroring `find_in_interlinks`'
+# short-circuit), then all inventories in user-declared order. Returns `nothing`
+# or `(href = absolute URL, label = display name, project = "Project X.Y.Z")`.
+function _interlinks_lookup(links::InterLinks, slug::AbstractString)
+    m = match(r"^@?(\w+)\.", slug)
+    if m !== nothing
+        inv = get(links.inventories, m.captures[1], nothing)
+        if inv !== nothing
+            hit = _inventory_lookup(inv, m.captures[1], slug)
+            hit === nothing || return hit
+        end
+    end
+    for name in links.names
+        hit = _inventory_lookup(links.inventories[name], name, slug)
+        hit === nothing || return hit
+    end
+    return nothing
+end
+
+function _inventory_lookup(inv, project::AbstractString, slug::AbstractString)
+    # domain="jl" keeps std:label/std:doc entries (section titles, pages) from
+    # colliding with code identifiers.
+    item = DocInventories.find_in_inventory(inv, slug; domain = "jl", quiet = true)
+    item === nothing && return nothing
+    return (
+        href = DocInventories.uri(item; root_url = inv.root_url),
+        label = item.dispname == "-" ? item.name : item.dispname,
+        project = isempty(inv.version) ? String(project) : string(project, " ", inv.version),
     )
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,11 @@
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+DocInventories = "43dc2714-ed3b-44b5-b226-857eda1aa7de"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+DocInventories = "0.4, 1"
 Documenter = "1.17"
+DocumenterInterLinks = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Test
 using Logging: Logging
 using Documenter: Documenter
+using DocInventories: Inventory, InventoryItem
+using DocumenterInterLinks: InterLinks
 using DocumenterCodeBlocks
 const DCB = DocumenterCodeBlocks
 
@@ -304,6 +306,92 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
         s, clipped = DCB._first_sentence("a "^150)   # 300 chars, no sentence boundary
         @test clipped && length(s) <= 200
         @test DCB._first_sentence("   ") == (nothing, false)
+    end
+
+    @testset "external links" begin
+        # Names without a local docstring fall back to the inventories of a
+        # DocumenterInterLinks plugin found in doc.plugins (no configuration on
+        # the CodeBlocks side). Built fully offline from an Inventory instance.
+        # NOTE: InterLinks' `alias_methods_as_function` aliases are only added
+        # for inventories loaded from file/URL, not Inventory instances — hence
+        # plain (non-method) names in the fake items.
+        inv = Inventory(
+            project = "Extern", version = "1.2.3",
+            root_url = "https://example.invalid/Extern/stable/",
+            items = [
+                InventoryItem(name = "Extern.frobnicate", role = "function", uri = "api/#Extern.frobnicate"),
+                InventoryItem(name = "Base.sort", role = "function", uri = "base/#Base.sort"),
+                InventoryItem(name = "Base.@time", role = "macro", uri = "base/#Base.@time"),
+                InventoryItem(name = "DocumenterCodeBlocks.CodeBlocks", role = "type", uri = "fake/#DocumenterCodeBlocks.CodeBlocks"),
+                InventoryItem(name = "Onlystd.thing", domain = "std", role = "label", uri = "labels/#thing"),
+            ],
+        )
+        page = """
+            # T
+
+            ```julia
+            sort([2, 1])
+            @time 1
+            Extern.frobnicate(1)
+            Onlystd.thing
+            frobnicate(1)
+            plugin = CodeBlocks()
+            ```
+
+            ```@docs
+            DocumenterCodeBlocks.CodeBlocks
+            ```
+            """
+        build(; plugins) = mktempdir() do dir
+            mkpath(joinpath(dir, "src"))
+            write(joinpath(dir, "src", "index.md"), page)
+            Logging.with_logger(Logging.NullLogger()) do
+                Documenter.makedocs(
+                    root = dir, sitename = "t", remotes = nothing, plugins = plugins,
+                    format = Documenter.HTML(edit_link = nothing, inventory_version = "0"),
+                )
+            end
+            return read(joinpath(dir, "build", "index.html"), String)
+        end
+        links = Logging.with_logger(Logging.NullLogger()) do
+            InterLinks("Extern" => inv)
+        end
+
+        html = build(plugins = [CodeBlocks(), links])
+        root = "https://example.invalid/Extern/stable/"
+        # Undocumented-locally names link out, marked external, via the
+        # fully qualified binding slug — including macros.
+        @test occursin(
+            "<a class=\"julia-ref external\" href=\"$(root)base/#Base.sort\">" *
+                "<span class=\"julia-funcall\">sort</span>", html,
+        )
+        @test occursin("href=\"$(root)base/#Base.@time\"", html)
+        # Verbatim dotted-name fallback: module `Extern` is not loaded here.
+        @test occursin("href=\"$(root)api/#Extern.frobnicate\"", html)
+        # External targets get a minimal tooltip naming the linked project.
+        @test occursin("data-for=\"$(root)base/#Base.sort\"", html)
+        @test occursin("External documentation (Extern 1.2.3).", html)
+        # std-domain entries (section labels) never match code identifiers.
+        @test !occursin("labels/#thing", html)
+        # Bare undefined identifiers don't reach the inventories.
+        @test !occursin("Extern/stable/\">frobnicate", html) && !occursin("#frobnicate", html)
+        # A local docstring wins over an inventory entry for the same name.
+        @test occursin(
+            "<a class=\"julia-ref\" href=\"#DocumenterCodeBlocks.CodeBlocks\">" *
+                "<span class=\"julia-funcall\">CodeBlocks</span>", html,
+        )
+        @test !occursin("fake/#DocumenterCodeBlocks.CodeBlocks", html)
+
+        # Opt-out kwarg: nothing links externally (local links remain).
+        html = build(plugins = [CodeBlocks(external_links = false), links])
+        @test !occursin("julia-ref external", html)
+        @test !occursin("example.invalid", html)
+        @test occursin("href=\"#DocumenterCodeBlocks.CodeBlocks\"", html)
+
+        # No InterLinks plugin at all: unchanged output, no external links.
+        html = build(plugins = [CodeBlocks()])
+        @test !occursin("julia-ref external", html)
+        @test !occursin("example.invalid", html)
     end
 
     @testset "docsite build" begin


### PR DESCRIPTION
Names in code blocks without a local docstring now fall back to the
inventories of a DocumenterInterLinks `InterLinks` plugin passed to
`makedocs` -- the same inventories the `@extref` prose macro uses. The
plugin is picked up automatically from `doc.plugins`; nothing is
configured on the CodeBlocks side.

Lookup uses the fully qualified binding slug ("Base.sort", "Base.@time")
and is restricted to jl-domain entries so section labels never capture
code identifiers. Qualified names whose package is not loaded in the
docs environment ("SomePkg.foo") are looked up verbatim. External links
carry the CSS class `julia-ref external`, are marked with a small NE
arrow, and their tooltip names the linked project and version. Opt out
with `CodeBlocks(external_links = false)`.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
