### PR TITLE
Smarter first-sentence detection for tooltip briefs (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.3.1] - Unreleased
+
+### Fixed
+ - Tooltip briefs no longer truncate the docstring's first sentence at
+   mid-sentence periods. A `.`/`!`/`?` now only ends the sentence when the
+   next word does not start with a lowercase letter (so `meas. outputs`,
+   `sort! the vector` and `args... to` continue) and when it does not
+   complete a known abbreviation such as `e.g.`, `i.e.`, `etc.` or `a.k.a.`.
+   Punctuation inside inline code is never a sentence end (`Base.sort!`
+   stays intact), while a code span starting the next word always is
+   ("Sort `v` in place. `alg` controls …" cuts before `alg`). ([#16])
+
 ## [v1.3.0] - 2026-08-13
 
 ### Added
@@ -90,6 +102,7 @@ See [README.md](README.md) and the documentation for details.
 [v1.1.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.1.0
 [v1.2.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.2.0
 [v1.3.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.3.0
+[v1.3.1]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.3.1
 [#3]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/3
 [#5]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/5
 [#6]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/6
@@ -100,3 +113,4 @@ See [README.md](README.md) and the documentation for details.
 [#12]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/12
 [#13]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/13
 [#14]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/14
+[#16]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/16

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocumenterCodeBlocks"
 uuid = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Fredrik Ekre <ekrefredrik@gmail.com>"]
 
 [deps]

--- a/src/references.jl
+++ b/src/references.jl
@@ -294,7 +294,7 @@ function _sig_and_brief(docsnode, object, arity = nothing, plugin = nothing)
                 if el isa Documenter.MarkdownAST.CodeBlock
                     first_block && (sig = String(strip(el.code)))
                 elseif el isa Documenter.MarkdownAST.Paragraph && brief === nothing
-                    brief, clipped = _first_sentence(_plain_text(child))
+                    brief, clipped = _first_sentence(_plain_text(child)...)
                 end
                 first_block = false
             end
@@ -345,29 +345,78 @@ function _synth_signature(object)
     return name
 end
 
-# Flatten a MarkdownAST subtree to its literal text (code spans included as-is).
+# Flatten a MarkdownAST subtree to its literal text (code spans included as-is,
+# their backticks dropped). Also returns the byte ranges the code spans occupy
+# in the flattened text, so sentence detection can tell code from prose.
 function _plain_text(node)
     io = IOBuffer()
-    _plain_text!(io, node)
-    return String(take!(io))
+    code_spans = UnitRange{Int}[]
+    _plain_text!(io, node, code_spans)
+    return String(take!(io)), code_spans
 end
-function _plain_text!(io, node)
+function _plain_text!(io, node, code_spans)
     el = node.element
     el isa Documenter.MarkdownAST.Text && print(io, el.text)
-    el isa Documenter.MarkdownAST.Code && print(io, el.code)
+    if el isa Documenter.MarkdownAST.Code
+        start = position(io) + 1
+        print(io, el.code)
+        push!(code_spans, start:position(io))
+    end
     for child in node.children
-        _plain_text!(io, child)
+        _plain_text!(io, child, code_spans)
     end
     return
 end
 
+# Abbreviations whose trailing `.` is not a sentence boundary. `meas`/`dist`/
+# `est` are ad-hoc truncations seen in the wild (#16); the rest are standard.
+const _ABBREVIATION_RE = r"(?:\b(?:e\.g|i\.e|etc|vs|cf|resp|approx|ca|viz|incl|meas|dist|est)|\bet\s+al|\bw\.r\.t|\ba\.k\.a|\bs\.t)\.$"i
+
 # First sentence of `text` (capped at 200 chars), whitespace-normalized.
-# Also reports whether the cap truncated mid-sentence (no boundary found in a
-# longer paragraph) — that feeds a docstring-quality warning.
-function _first_sentence(text)
-    m = match(r"^.{1,200}?[.!?](?=\s|$)"s, text)
-    clipped = m === nothing && length(text) > 200
-    s = m === nothing ? first(text, 200) : m.match
+# A sentence ends at `.`/`!`/`?` followed by whitespace or end of text, except
+# that (following Unicode UAX #29 rule SB8, validated against Base/stdlib
+# docstrings) the sentence continues when the next word starts with a lowercase
+# prose letter — abbreviations like `meas. outputs` and bang functions like
+# `sort! the vector` — or when the `.` completes a known abbreviation (`e.g.
+# Native code`). Punctuation inside a code span never ends the sentence
+# (`Base.sort!` stays intact), but a code span *starting* the next word does
+# end it: briefs of the ubiquitous form "Sort `v` in place. `alg` controls …"
+# must cut before `alg` regardless of its case. Also reports whether the cap
+# truncated mid-sentence (no boundary found in a longer paragraph) — that
+# feeds a docstring-quality warning.
+function _first_sentence(text, code_spans = UnitRange{Int}[])
+    incode(i) = any(r -> i in r, code_spans)
+    lastidx = lastindex(text)
+    stop = 0
+    nchars = 0
+    i = firstindex(text)
+    while i <= lastidx && nchars < 200
+        nchars += 1
+        c = text[i]
+        if (c === '.' || c === '!' || c === '?') && !incode(i)
+            k = nextind(text, i)
+            wasspace = k > lastidx || isspace(text[k])
+            while k <= lastidx && isspace(text[k])
+                k = nextind(text, k)
+            end
+            if !wasspace
+                # punctuation embedded in a word (`1.5`, `e.g` in `e.g.`): no boundary
+            elseif k > lastidx
+                stop = i
+                break
+            elseif islowercase(text[k]) && !incode(k)
+                # next word is lowercase prose: the sentence continues
+            elseif c === '.' && occursin(_ABBREVIATION_RE, SubString(text, firstindex(text), i))
+                # known abbreviation: the sentence continues
+            else
+                stop = i
+                break
+            end
+        end
+        i = nextind(text, i)
+    end
+    clipped = stop == 0 && length(text) > 200
+    s = stop == 0 ? first(text, 200) : text[begin:stop]
     s = strip(replace(s, r"\s+" => " "))
     return (isempty(s) ? nothing : String(s)), clipped
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -304,6 +304,39 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
         s, clipped = DCB._first_sentence("a "^150)   # 300 chars, no sentence boundary
         @test clipped && length(s) <= 200
         @test DCB._first_sentence("   ") == (nothing, false)
+        # a lowercase next word means the sentence continues (abbreviations,
+        # bang functions, ellipses); uppercase/digit/punctuation ends it (#16)
+        @test DCB._first_sentence("Uses meas. outputs and dist. values for control. Second sentence.") ==
+            ("Uses meas. outputs and dist. values for control.", false)
+        @test DCB._first_sentence("Call sort! on the vector. More.") ==
+            ("Call sort! on the vector.", false)
+        @test DCB._first_sentence("Writes args... to a string. More.") ==
+            ("Writes args... to a string.", false)
+        @test DCB._first_sentence("Returns f(x) ? a : b. More.") ==
+            ("Returns f(x) ? a : b.", false)
+        # known abbreviations don't end the sentence even before a capital
+        @test DCB._first_sentence("Allocated for e.g. Native code. More.") ==
+            ("Allocated for e.g. Native code.", false)
+        @test DCB._first_sentence("Compose functions: i.e. (f o g)(x) means f(g(x)).") ==
+            ("Compose functions: i.e. (f o g)(x) means f(g(x)).", false)
+        @test DCB._first_sentence("Scalar replacement, a.k.a. SROA. More.") ==
+            ("Scalar replacement, a.k.a. SROA.", false)
+        # punctuation inside a code span never ends the sentence; a code span
+        # starting the next word always does, whatever its case
+        @test DCB._first_sentence("Calls Base.sort! internally to sort. More.", [7:16]) ==
+            ("Calls Base.sort! internally to sort.", false)
+        @test DCB._first_sentence("Sort v in place. alg controls the algorithm.", [6:6, 18:20]) ==
+            ("Sort v in place.", false)
+        # end-to-end through _plain_text: code spans in a docstring paragraph
+        para = Documenter.MarkdownAST.@ast Documenter.MarkdownAST.Paragraph() do
+            "Prepare "
+            Documenter.MarkdownAST.Code("estim.x0")
+            " estimate with meas. outputs "
+            Documenter.MarkdownAST.Code("ym")
+            " for the step. Second sentence."
+        end
+        @test DCB._first_sentence(DCB._plain_text(para)...) ==
+            ("Prepare estim.x0 estimate with meas. outputs ym for the step.", false)
     end
 
     @testset "docsite build" begin


### PR DESCRIPTION
Tooltip briefs cut the docstring's first paragraph at the first `.`/`!`/`?`
followed by whitespace, which truncated too early on mid-sentence periods:
abbreviations ("meas. outputs", "e.g. Native code"), bang functions
("calling `sort!` on"), and ellipses ("writes `args...` to").

A boundary now only ends the sentence when the next word does not start
with a lowercase prose letter (Unicode UAX #29 rule SB8) and the period
does not complete a known abbreviation (e.g., i.e., etc., a.k.a., ...).
Code spans are boundary-opaque: `_plain_text` reports the byte ranges
inline code occupies in the flattened text, so punctuation inside code
never ends the sentence, while a code span starting the next word always
does — validated against ~4900 docstring first paragraphs from Base,
the stdlibs, and registered packages.

Closes #16.
