### PR TITLE
Allow summary to precede signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    contexts without clipboard access the click degrades to the previous
    behavior (URL fragment only). ([#17])
 
+### Changed
+ - A docstring's signature block is now its first code block, which the
+   summary paragraph may precede; the brief remains the first sentence of the
+   first prose paragraph, before or after that block. A code block further
+   down — under a `# Examples` heading, say — is still example code, and a
+   docstring without a signature block is still reported as such. ([#19])
+
 ### Fixed
  - Tooltip briefs no longer truncate the docstring's first sentence at
    mid-sentence periods. A `.`/`!`/`?` now only ends the sentence when the
@@ -125,3 +132,4 @@ See [README.md](README.md) and the documentation for details.
 [#14]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/14
 [#16]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/16
 [#17]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/17
+[#19]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/19

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -62,7 +62,7 @@ a reference with the enclosing docstring among its candidate targets is left
 unlinked — it (possibly) means the very thing the reader is looking at. A
 call whose arity resolves to a *different* documented method still links, so
 an example in [`foo(a, b)`](@ref)'s docstring that calls `foo(1)` links to
-[`foo(a)`](@ref). The **signature header** — a docstring's leading code
+[`foo(a)`](@ref). The **signature header** — a docstring's first code
 block — links its argument and return types the same way (see
 [`clone`](@ref)'s header in the API reference, which links `MyType` twice),
 while the documented name and the parameters stay plain.

--- a/docs/src/warnings.md
+++ b/docs/src/warnings.md
@@ -1,8 +1,8 @@
 # [Docstring warnings](@id warnings)
 
 The [tooltips](@ref tooltips) extract two things from every referenced
-docstring: the **signature** (the docstring's leading code block, the Julia
-convention) and a **brief** (the first sentence of the first paragraph). When
+docstring: the **signature** (the docstring's first code block) and a
+**brief** (the first sentence of its first prose paragraph). When
 a docstring doesn't provide them, the tooltip degrades gracefully — and the
 build emits a warning telling the author what to fix. The aim is to nudge
 docstrings toward a shape that works well in tooltips and reads well
@@ -11,14 +11,14 @@ everywhere else, too.
 The warnings are prefixed `CodeBlocks: `, fire **once per problem** per
 build, and only for docstrings that some code block actually references.
 
-## No leading signature block
+## No signature block
 
 The tooltip falls back to a signature synthesized from the method object:
 
 ```nohighlight
-┌ Warning: CodeBlocks: the docstring for `MyPackage.frob (Tuple{Int64})` does not start
-│ with a signature code block; tooltips fall back to the synthesized signature
-│ `frob(::Int64)`. Start the docstring with the indented signature (the Julia convention):
+┌ Warning: CodeBlocks: the docstring for `MyPackage.frob (Tuple{Int64})` has no signature
+│ code block; tooltips fall back to the synthesized signature `frob(::Int64)`. Give it
+│ one, either leading (the Julia convention) or directly after the summary paragraph:
 │     """
 │         frob(::Int64)
 │

--- a/src/DocumenterCodeBlocks.jl
+++ b/src/DocumenterCodeBlocks.jl
@@ -78,9 +78,9 @@ arity resolves to a different documented method still link.
 
 Build warnings prefixed `CodeBlocks: ` nudge toward tooltip-friendly (and
 generally better) docstrings: they fire — once per problem, and only for
-docstrings some code block references — when a docstring lacks a leading
-signature block or a prose first sentence, when the first sentence exceeds
-200 characters, and when a call's arity matches no documented method.
+docstrings some code block references — when a docstring lacks a signature
+block or a prose first sentence, when the first sentence exceeds 200
+characters, and when a call's arity matches no documented method.
 
 Pass to `makedocs(plugins=[CodeBlocks()])`.
 """

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -404,13 +404,17 @@ function process_html(html::AbstractString, plugin::CodeBlocks, doc, page)
         end
         meta = _consume_blockmeta!(plugin, doc, page, kind, source)
         mod = meta === nothing ? nothing : meta.mod
-        # A doctest after the summary paragraph is example code, not a
-        # signature: a script-style `jldoctest` renders as `language-julia`
-        # like any other block, so only its fence — recorded by the ScanStep —
-        # tells the two apart. (A block that LEADS the docstring counts as the
-        # signature whatever its fence, as it always has.)
+        # A doctest or a series-named fence after the summary paragraph is
+        # example code, not a signature (`_is_example_block` on the AST side).
+        # Both render as `language-julia` like any other block, so only the
+        # fence — recorded by the ScanStep as a jldoctest crc / a BlockMeta
+        # name — tells them apart. (A block that LEADS the docstring counts as
+        # the signature whatever its fence, as it always has.)
         sigpos = kind === :block ? _docstring_sig_position(html, m.offset) : nothing
-        if sigpos === :first || (sigpos === :second && !(crc32c(source) in plugin.jldoctests))
+        if sigpos === :first || (
+                sigpos === :second && !(crc32c(source) in plugin.jldoctests) &&
+                    (meta === nothing || meta.name === nothing)
+            )
             # Signature headers have no gutter: no counter interaction.
             print(io, transform_signature_block(source, plugin, doc, page, tips, self_ids, mod))
             continue

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -288,9 +288,7 @@ function _preceded_by(html, offset, prefix)
     return true
 end
 
-# The first code block of a docstring is its signature header, rendered as the
-# first element of the docstring's `<section><div>` — where the `<section>` of
-# an aggregated entry may carry a per-docstring sub-anchor id. By convention
+# The first code block of a docstring is its signature header. By convention
 # the header is not example code — it gets no gutter and no id/permalink, and
 # it isn't always valid Julia (optional-argument brackets like `f(x[, y])`) —
 # but the argument and return types in it do get reference links (issue #11):
@@ -298,7 +296,24 @@ end
 # while `::`/`{}` type positions and the `-> T` return-type convention link.
 # The documented name itself never links: it is a self reference (candidate-
 # aware, so same-arity siblings count as self too).
-function _docstring_sig_prefix(html, offset)
+#
+# In the rendered docstring the header is the first element of the
+# `<section><div>` (`:first`) — or the one right after the paragraph holding
+# the summary (`:second`), the same two positions `_signature_node` accepts in
+# the AST; `nothing` anywhere else.
+function _docstring_sig_position(html, offset)
+    _section_div_at(html, offset) && return :first
+    # Paragraphs cannot nest, so the closest preceding `<p>` opens the one the
+    # block follows; nothing may sit between them.
+    _preceded_by(html, offset, "</p>") || return nothing
+    p = findprev("<p>", html, offset)
+    return (p !== nothing && _section_div_at(html, first(p))) ? :second : nothing
+end
+
+# Whether `offset` directly follows the `<section><div>` opening a docstring's
+# body — where the `<section>` of an aggregated entry may carry a per-docstring
+# sub-anchor id.
+function _section_div_at(html, offset)
     _preceded_by(html, offset, "<div>") || return false
     j = offset - ncodeunits("<div>") - 1   # the byte just before "<div>"
     (j >= 1 && codeunit(html, j) == UInt8('>')) || return false
@@ -389,7 +404,13 @@ function process_html(html::AbstractString, plugin::CodeBlocks, doc, page)
         end
         meta = _consume_blockmeta!(plugin, doc, page, kind, source)
         mod = meta === nothing ? nothing : meta.mod
-        if kind === :block && _docstring_sig_prefix(html, m.offset)
+        # A doctest after the summary paragraph is example code, not a
+        # signature: a script-style `jldoctest` renders as `language-julia`
+        # like any other block, so only its fence — recorded by the ScanStep —
+        # tells the two apart. (A block that LEADS the docstring counts as the
+        # signature whatever its fence, as it always has.)
+        sigpos = kind === :block ? _docstring_sig_position(html, m.offset) : nothing
+        if sigpos === :first || (sigpos === :second && !(crc32c(source) in plugin.jldoctests))
             # Signature headers have no gutter: no counter interaction.
             print(io, transform_signature_block(source, plugin, doc, page, tips, self_ids, mod))
             continue

--- a/src/references.jl
+++ b/src/references.jl
@@ -267,8 +267,9 @@ end
 # precede. Nothing further down counts: a docstring section heading renders as
 # a paragraph of its own (Documenter's `recursive_heading_to_bold!`), so
 # requiring adjacency keeps `# Examples` code out. A block that does not lead
-# the docstring must also be example-free: unlabeled or an explicit `julia`
-# fence, and not a doctest (`Documenter.doctest_replace!` has by now relabeled
+# the docstring must also be example-free: unlabeled or a bare `julia` fence
+# (a series name marks example code), and not a doctest
+# (`Documenter.doctest_replace!` has by now relabeled
 # every `jldoctest` fence `julia`/`julia-repl`, so the ScanStep's record of
 # the original fences is what tells them apart). `_docstring_sig_position`
 # recognizes the same two positions in the rendered HTML.

--- a/src/references.jl
+++ b/src/references.jl
@@ -216,9 +216,10 @@ function _target_info(doc, object, from, prettyurls, arity = nothing, plugin = n
     if info.synthesized
         _warn_once(
             plugin, "sig:" * name,
-            "the docstring for `$(name)` does not start with a signature code block; " *
+            "the docstring for `$(name)` has no signature code block; " *
                 "tooltips fall back to the synthesized signature `$(info.sig)`. " *
-                "Start the docstring with the indented signature (the Julia convention):\n" *
+                "Give it one, either leading (the Julia convention) or directly " *
+                "after the summary paragraph:\n" *
                 "    \"\"\"\n        $(info.sig)\n\n    ...\n    \"\"\"",
         )
     end
@@ -261,20 +262,48 @@ function _collapse_sig(sig)
     return String(strip(s))
 end
 
+# The signature code block of a docstring, as a MarkdownAST node, or `nothing`.
+# It is the docstring's first code block, which the summary paragraph may
+# precede. Nothing further down counts: a docstring section heading renders as
+# a paragraph of its own (Documenter's `recursive_heading_to_bold!`), so
+# requiring adjacency keeps `# Examples` code out. A block that does not lead
+# the docstring must also be example-free: unlabeled or an explicit `julia`
+# fence, and not a doctest (`Documenter.doctest_replace!` has by now relabeled
+# every `jldoctest` fence `julia`/`julia-repl`, so the ScanStep's record of
+# the original fences is what tells them apart). `_docstring_sig_position`
+# recognizes the same two positions in the rendered HTML.
+function _signature_node(md, plugin = nothing)
+    i = 0
+    for child in md.children
+        el = child.element
+        i += 1
+        if el isa Documenter.MarkdownAST.CodeBlock
+            i == 1 && return child
+            return _is_example_block(el, plugin) ? nothing : child
+        end
+        (i == 1 && el isa Documenter.MarkdownAST.Paragraph) || return nothing
+    end
+    return nothing
+end
+
+_is_example_block(el, plugin) =
+    !(isempty(el.info) || el.info == "julia") ||
+    (plugin !== nothing && crc32c(el.code) in plugin.jldoctests)
+
 # Signature, one-line label, and brief for a docstring, tolerating the many
 # shapes Julia docstrings come in:
-# - Signature: the LEADING code block of the relevant docstring(s). An
-#   aggregated entry — a bare `@docs Mod.f` — holds one docstring per method
-#   (mdasts/results/metas are parallel vectors); when the call arity is known,
-#   the entry is narrowed to the docstrings whose dispatch signature
-#   (`results[i].data[:typesig]`) accepts that arity, else ALL signature blocks
-#   show, joined by newlines. A code block that merely appears later (e.g. in
-#   Examples) is NOT a signature. Without any, the signature is synthesized
-#   from the documented method object itself.
+# - Signature: the signature block of the relevant docstring(s), see
+#   `_signature_node`. An aggregated entry — a bare `@docs Mod.f` — holds one
+#   docstring per method (mdasts/results/metas are parallel vectors); when the
+#   call arity is known, the entry is narrowed to the docstrings whose dispatch
+#   signature (`results[i].data[:typesig]`) accepts that arity, else ALL
+#   signature blocks show, joined by newlines. Without any, the signature is
+#   synthesized from the documented method object itself.
 # - Label: the first signature block collapsed to one line (multiline headers
 #   would otherwise show as just `foo(` in disambiguation lists).
-# - Brief: the first paragraph of the narrowed docstring(s), flattened to plain
-#   text and clipped to its first sentence; `nothing` without prose.
+# - Brief: the first prose paragraph of the narrowed docstring(s) — before or
+#   after the signature — flattened to plain text and clipped to its first
+#   sentence; `nothing` without prose.
 # Returns (sig, label, brief, narrowed, subidx, synthesized, brief_clipped) —
 # `narrowed` says arity selection actually dropped something (the caller keys
 # the tip payload on it), and `subidx` is the docstring's index within the
@@ -285,18 +314,14 @@ function _sig_and_brief(docsnode, object, arity = nothing, plugin = nothing)
     docs = @NamedTuple{sig::Union{Nothing, String}, brief::Union{Nothing, String}, clipped::Bool, typesig::Any, idx::Int}[]
     if docsnode !== nothing
         for (i, md) in enumerate(docsnode.mdasts)
-            sig = nothing
+            signode = _signature_node(md, plugin)
+            sig = signode === nothing ? nothing : String(strip(signode.element.code))
             brief = nothing
             clipped = false
-            first_block = true
             for child in md.children
-                el = child.element
-                if el isa Documenter.MarkdownAST.CodeBlock
-                    first_block && (sig = String(strip(el.code)))
-                elseif el isa Documenter.MarkdownAST.Paragraph && brief === nothing
+                if child.element isa Documenter.MarkdownAST.Paragraph && brief === nothing
                     brief, clipped = _first_sentence(_plain_text(child)...)
                 end
-                first_block = false
             end
             typesig = i <= length(docsnode.results) ?
                 get(docsnode.results[i].data, :typesig, Union{}) : Union{}

--- a/test/docsite/demo.jl
+++ b/test/docsite/demo.jl
@@ -327,6 +327,46 @@ and `clone` itself stay plain.
 """
 clone(m::MyType; deep::Bool = false) = MyType(m.x)
 
+"""Double `x`. This docstring puts its summary paragraph ahead of the
+signature block:
+
+```julia
+y = summarize(x)
+```
+
+assigns the doubled value to `y`. The signature is the docstring's first code
+block either way, so it gets the header treatment (highlighted, no gutter, no
+permalink) and feeds the tooltip, with the brief taken from the first prose
+paragraph.
+"""
+summarize(x) = 2x
+
+"""Return `x` unchanged. The block below follows the summary paragraph
+directly, but a doctest is example code whatever its position: it keeps its
+gutter and its `# output` split, and the tooltip signature is synthesized.
+
+```jldoctest
+println(add_numbers(echoed(1), 2))
+
+# output
+
+3
+```
+"""
+echoed(x) = x
+
+"""Return `x` unchanged. The only code block here sits further down, under a
+section heading: it is an example, so it keeps its line-number gutter and the
+tooltip signature is synthesized (with a build warning).
+
+# Examples
+
+```julia
+s = sampled(add_numbers(1, 2))
+```
+"""
+sampled(x) = x
+
 """
     @twice(expr)
 

--- a/test/docsite/demo.jl
+++ b/test/docsite/demo.jl
@@ -367,6 +367,17 @@ s = sampled(add_numbers(1, 2))
 """
 sampled(x) = x
 
+"""Halve `x`. The named fence below follows the summary paragraph directly,
+but the name puts it in a numbering series — example code, like a doctest in
+that position: it keeps its gutter and the tooltip signature is synthesized
+(with a build warning).
+
+```julia halved
+y = halved(add_numbers(2, 2))
+```
+"""
+halved(x) = x / 2
+
 """
     @twice(expr)
 

--- a/test/docsite/make.jl
+++ b/test/docsite/make.jl
@@ -21,7 +21,7 @@ end
 DocMeta.setdocmeta!(
     DocumenterCodeBlocks,
     :DocTestSetup,
-    :(import DocumenterCodeBlocks: greet, add_numbers, MyType, foo);
+    :(import DocumenterCodeBlocks: greet, add_numbers, MyType, foo, echoed);
     recursive = true,
 )
 

--- a/test/docsite/src/index.md
+++ b/test/docsite/src/index.md
@@ -50,6 +50,7 @@ DocumenterCodeBlocks.clone
 DocumenterCodeBlocks.summarize
 DocumenterCodeBlocks.echoed
 DocumenterCodeBlocks.sampled
+DocumenterCodeBlocks.halved
 DocumenterCodeBlocks.@twice
 DocumenterCodeBlocks.@w_str
 ```

--- a/test/docsite/src/index.md
+++ b/test/docsite/src/index.md
@@ -47,6 +47,9 @@ DocumenterCodeBlocks.fit(X::AbstractMatrix, w::AbstractVector)
 DocumenterCodeBlocks.process(data::AbstractMatrix, weights::AbstractVector)
 DocumenterCodeBlocks.process(data::AbstractVector)
 DocumenterCodeBlocks.clone
+DocumenterCodeBlocks.summarize
+DocumenterCodeBlocks.echoed
+DocumenterCodeBlocks.sampled
 DocumenterCodeBlocks.@twice
 DocumenterCodeBlocks.@w_str
 ```

--- a/test/docsite/src/references.md
+++ b/test/docsite/src/references.md
@@ -78,6 +78,18 @@ w = wordy(1)       # first sentence >200 chars → brief truncated (build warnin
 Each of the imperfect cases above also emits a `CodeBlocks: ` build warning
 telling the docstring author what to fix.
 
+The signature is the docstring's first code block and the brief its first
+prose paragraph, whichever order the two appear in: `summarize` writes the
+summary paragraph first and the signature block after it. In `sampled` the
+only code block sits further down, under a heading — that one is an example,
+so its tooltip signature is synthesized.
+
+```julia
+u = summarize(2)   # signature block after the summary paragraph
+e = echoed(u)      # doctest after the summary paragraph → still an example
+s = sampled(e)     # code block under a heading → synthesized signature
+```
+
 ## Type annotations
 
 `qux` has two documented methods of the **same arity** that differ only in the

--- a/test/docsite/src/references.md
+++ b/test/docsite/src/references.md
@@ -88,6 +88,7 @@ so its tooltip signature is synthesized.
 u = summarize(2)   # signature block after the summary paragraph
 e = echoed(u)      # doctest after the summary paragraph → still an example
 s = sampled(e)     # code block under a heading → synthesized signature
+h = halved(s)      # named fence after the summary → still an example
 ```
 
 ## Type annotations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -348,7 +348,7 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
             include(joinpath(docsite, "make.jl"))
         end
         cb = [String(l.message) for l in logger.logs if startswith(String(l.message), "CodeBlocks: ")]
-        @test length(cb) == 7
+        @test length(cb) == 8
         @test any(contains("`DocumenterCodeBlocks.bar`"), cb)             # no signature block
         @test any(contains("`DocumenterCodeBlocks.baz` has no prose"), cb)
         @test any(contains("`DocumenterCodeBlocks.wordy`"), cb)           # clipped brief
@@ -356,6 +356,7 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
         @test any(contains("takes 4 arguments"), cb)                      # arity gap
         @test any(contains("sampled"), cb)        # code block under a heading
         @test any(contains("echoed"), cb)         # doctest after the summary
+        @test any(contains("halved"), cb)         # named fence after the summary
         # A signature block after the summary paragraph is found, not reported.
         @test !any(contains("summarize"), cb)
         other = [String(l.message) for l in logger.logs if !startswith(String(l.message), "CodeBlocks: ")]
@@ -541,6 +542,13 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
             @test occursin("class=\"nohighlight hljs line-numbers\"", echoed)
             out = match(r"# output(.{0,80})"s, echoed)
             @test out !== nothing && !occursin("julia-", out.captures[1])
+            # A NAMED fence in the signature position joins a numbering
+            # series: example code (the AST side sees the name on the fence,
+            # the HTML side the ScanStep's BlockMeta), so it too keeps its
+            # gutter and permalink id (and warning above).
+            halved = docstring_details(index, "DocumenterCodeBlocks.halved")
+            @test occursin("<pre id=\"c-", halved)
+            @test occursin("class=\"nohighlight hljs line-numbers\"", halved)
         end
 
         @testset "self references in docstrings" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -348,12 +348,16 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
             include(joinpath(docsite, "make.jl"))
         end
         cb = [String(l.message) for l in logger.logs if startswith(String(l.message), "CodeBlocks: ")]
-        @test length(cb) == 5
+        @test length(cb) == 7
         @test any(contains("`DocumenterCodeBlocks.bar`"), cb)             # no signature block
         @test any(contains("`DocumenterCodeBlocks.baz` has no prose"), cb)
         @test any(contains("`DocumenterCodeBlocks.wordy`"), cb)           # clipped brief
         @test any(contains("neg"), cb)                                    # typed, synthesized
         @test any(contains("takes 4 arguments"), cb)                      # arity gap
+        @test any(contains("sampled"), cb)        # code block under a heading
+        @test any(contains("echoed"), cb)         # doctest after the summary
+        # A signature block after the summary paragraph is found, not reported.
+        @test !any(contains("summarize"), cb)
         other = [String(l.message) for l in logger.logs if !startswith(String(l.message), "CodeBlocks: ")]
         @test isempty(other)   # the docsite build itself must be warning-clean
 
@@ -501,6 +505,42 @@ const SUBANCHORS = hasfield(Documenter.DocsNode, :subslugs)
             # (the candidate targets include the enclosing docstring).
             quxs = sig_header(docstring_details(index, "DocumenterCodeBlocks.qux-Tuple{String}"))
             @test !occursin("julia-ref", quxs)
+        end
+
+        @testset "signature block after the summary" begin
+            # `summarize` puts its summary paragraph before the signature
+            # block: the block is still the docstring's first, so it gets the
+            # header treatment (highlighted, no id, no gutter) and the
+            # documented name stays a self reference.
+            d = docstring_details(index, "DocumenterCodeBlocks.summarize")
+            m = match(
+                r"<section[^>]*><div><p>.*?</p><pre><code class=\"nohighlight hljs\">(.*?)</code></pre>"s,
+                d,
+            )
+            @test m !== nothing
+            @test occursin("<span class=\"julia-funcall\">summarize</span>", m.captures[1])
+            @test !occursin("julia-ref", m.captures[1])
+            # Its tooltip shows that block, not a synthesized signature, with
+            # the brief from the paragraph above it.
+            @test occursin(
+                "data-for=\"../#DocumenterCodeBlocks.summarize\">" *
+                    "<code class=\"ref-tip-sig nohighlight\">y <span class=\"julia-keyword\">=</span> " *
+                    "<span class=\"julia-funcall\">summarize</span>(x)</code>" *
+                    "<p class=\"ref-tip-brief\">Double x.",
+                refs,
+            )
+            # `sampled`'s only code block sits under a heading: an example,
+            # keeping its gutter and permalink id (and warning above).
+            sampled = docstring_details(index, "DocumenterCodeBlocks.sampled")
+            @test occursin("<pre id=\"c-", sampled)
+            @test occursin("class=\"nohighlight hljs line-numbers\"", sampled)
+            # `echoed`'s doctest sits in the signature position but renders as
+            # a script-style doctest: gutter, and no highlighting past
+            # `# output`.
+            echoed = docstring_details(index, "DocumenterCodeBlocks.echoed")
+            @test occursin("class=\"nohighlight hljs line-numbers\"", echoed)
+            out = match(r"# output(.{0,80})"s, echoed)
+            @test out !== nothing && !occursin("julia-", out.captures[1])
         end
 
         @testset "self references in docstrings" begin


### PR DESCRIPTION
With this PR, the "brief" or "summary" is the first sentence of the docstring's first prose paragraph, and the signature is its first code block (up to a bound, see below), in whichever order the two appear. The Julia manual's shape keeps working exactly as before, and a docstring that opens with the summary and follows it with the signature block now works too.

This is implemented as discussed in #19, using the "middle ground" behavior: the signature block has to lead the docstring or follow the summary paragraph directly. That bound is what keeps example code from being promoted. A docstring like

````julia
"""Do a thing.

# Examples

```julia
y = do_thing(1)
```
"""
````

is common, and under an unbounded rule its example would become the signature. Requiring adjacency handles that without a heuristic on the block's contents: Documenter rewrites a docstring heading into a bold paragraph of its own (`recursive_heading_to_bold!`), so a heading breaks the adjacency, as does any second paragraph.

The bound also lines up the two halves of the plugin. Tooltip extraction reads the docstring AST, but the header treatment (highlight, no gutter, no permalink, binding-context links) is decided post-render from the block's position inside the docstring's `<section><div>`. Both now recognize the same two positions, so what the tooltip calls the signature and what the renderer draws as a header cannot disagree.

Two smaller conditions apply to a block that does not lead the docstring, since at that position example code is genuinely possible:

- It must be unlabeled or an explicit ```` ```julia ```` fence. A `julia-repl` transcript there is an example.
- It must not be a doctest. `doctest_replace!` relabels every `jldoctest` fence `julia` before the plugin sees the AST, so the fences recorded by the ScanStep (already kept for the `# output` split) are what tell a doctest from a signature. Without this, a doctest right after the summary would lose its gutter and have its expected output highlighted as Julia.

A block that leads the docstring still counts as the signature whatever its fence, as before.

## Changes

- `_signature_node` replaces the inline "first child is a code block" test in `_sig_and_brief`.
- `_docstring_sig_prefix` becomes `_docstring_sig_position`, returning `:first`, `:second`, or `nothing`; the `<section><div>` test factors out into `_section_div_at`.
- The "no signature block" warning no longer says "does not start with", and points at both positions.
- Testbed: `summarize` (summary paragraph, then the signature block), `echoed` (a doctest in that position, still an example), and `sampled` (the only code block under a heading, still an example). The docsite build asserts the header treatment, the tooltip contents, the retained gutters, and the warning set.


Co-authored by Claude.

Closes #19.