### PR TITLE
Copy button copies only the selected lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.5.0] - Unreleased
+
+### Added
+ - Documenter's copy-code button now copies only the selected lines when the
+   block has a line selection (click/shift-click/drag in the gutter), matching
+   the permalink button next to it. Without a selection it copies the whole
+   block as before. ([#26], [#27])
 
 ### Fixed
  - The permalink and copy-code icons are no longer misaligned on code
@@ -121,6 +127,7 @@ See [README.md](README.md) and the documentation for details.
 [v1.2.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.2.0
 [v1.3.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.3.0
 [v1.4.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.4.0
+[v1.5.0]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/releases/tag/v1.5.0
 [#3]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/3
 [#5]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/5
 [#6]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/6
@@ -135,3 +142,5 @@ See [README.md](README.md) and the documentation for details.
 [#17]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/17
 [#23]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/23
 [#25]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/25
+[#26]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/26
+[#27]: https://github.com/fredrikekre/DocumenterCodeBlocks.jl/issues/27

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocumenterCodeBlocks"
 uuid = "b6400b83-267f-4b55-9fd8-bffc853bdfd8"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Fredrik Ekre <ekrefredrik@gmail.com>"]
 
 [deps]

--- a/assets/line-numbers.js
+++ b/assets/line-numbers.js
@@ -10,7 +10,8 @@
  * Line numbers render from CSS counters with zero JS. This script only adds the
  * client-side interactions: the permalink button (a real anchor that copies the
  * block/selection URL to the clipboard), gutter click/shift-click/drag
- * selection, and hash restore.
+ * selection, hash restore, and a hook that makes Documenter's own copy-code
+ * button copy just the selected lines when the block has a line selection.
  *
  * Hash formats:  #c-1a2b3c4d          whole block
  *                #c-1a2b3c4d-L5       single line
@@ -61,41 +62,41 @@
         e.preventDefault();
         // An active line selection in this block is what the user means to
         // share — keep it; otherwise (re)target the whole block.
-        const m = HASH_RE.exec(location.hash);
-        if (!(m && m[1] === pre.id && m[2])) setHash("#" + pre.id);
+        if (!selectedRange(pre)) setHash("#" + pre.id);
         copyText(location.href, link);
       });
       pre.appendChild(link);
     });
   }
 
-  // Copy `text` to the clipboard and flash `link`'s icon to a checkmark.
-  // navigator.clipboard requires a secure context (https or localhost); on
-  // plain-http or file:// views fall back to a transient textarea +
-  // execCommand. If both fail the click has still set the hash, which is the
-  // pre-copy behavior.
-  function copyText(text, link) {
-    let copied;
+  // Write `text` to the clipboard; resolves on success. navigator.clipboard
+  // requires a secure context (https or localhost); on plain-http or file://
+  // views fall back to a transient textarea + execCommand.
+  function writeClipboard(text) {
     if (navigator.clipboard && window.isSecureContext) {
-      copied = navigator.clipboard.writeText(text);
-    } else {
-      copied = new Promise(function (resolve, reject) {
-        const ta = document.createElement("textarea");
-        ta.value = text;
-        ta.style.position = "fixed";
-        ta.style.opacity = "0";
-        document.body.appendChild(ta);
-        ta.select();
-        try {
-          document.execCommand("copy") ? resolve() : reject(new Error("execCommand"));
-        } catch (err) {
-          reject(err);
-        } finally {
-          ta.remove();
-        }
-      });
+      return navigator.clipboard.writeText(text);
     }
-    copied.then(function () {
+    return new Promise(function (resolve, reject) {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand("copy") ? resolve() : reject(new Error("execCommand"));
+      } catch (err) {
+        reject(err);
+      } finally {
+        ta.remove();
+      }
+    });
+  }
+
+  // Copy `text` and flash `link`'s icon to a checkmark. If the copy fails the
+  // click has still set the hash, which is the pre-copy behavior.
+  function copyText(text, link) {
+    writeClipboard(text).then(function () {
       link.innerHTML = CHECK_SVG;
       link.classList.add("copied");
       clearTimeout(link._copiedTimer);
@@ -104,6 +105,45 @@
         link.classList.remove("copied");
       }, 1500);
     }).catch(function () {});
+  }
+
+  // ---- Documenter's copy-code button: copy only the selected lines (#26) --
+  //
+  // Documenter's copy.js appends `<button class="copy-button fa-solid fa-copy">`
+  // to every <pre> and attaches a click listener copying `pre.innerText`. We do
+  // not touch that asset: a capture-phase listener on `document` runs before
+  // any listener on the button itself regardless of script load order. When
+  // the block has a line selection we take over the click — copy just those
+  // lines and replay copy.js's feedback (success/fa-check, error/fa-xmark,
+  // restored after 5 s). Without a selection we step aside and Documenter's
+  // handler copies the whole block exactly as before.
+  function onCopyClick(e) {
+    const btn = e.target.closest(".copy-button");
+    if (!btn) return;
+    const pre = btn.closest('article pre[id^="c-"]');
+    const r = pre && selectedRange(pre);
+    if (!r) return;
+    e.stopImmediatePropagation();
+    e.preventDefault();
+    const lines = Array.prototype.slice.call(pre.querySelectorAll(".line"), r.a - 1, r.b);
+    // Same shape as pre.innerText (what copy.js copies): "\n"-joined lines,
+    // no trailing newline.
+    const text = lines.map(function (l) { return l.textContent; }).join("\n");
+    writeClipboard(text).then(
+      function () {
+        btn.classList.add("success", "fa-check");
+        btn.classList.remove("fa-copy");
+      },
+      function () {
+        btn.classList.add("error", "fa-xmark");
+        btn.classList.remove("fa-copy");
+      }
+    );
+    clearTimeout(btn._copiedTimer);
+    btn._copiedTimer = setTimeout(function () {
+      btn.classList.add("fa-copy");
+      btn.classList.remove("success", "fa-check", "error", "fa-xmark");
+    }, 5000);
   }
 
   function armGutters() {
@@ -127,6 +167,19 @@
     a += off;
     b += off;
     return a === b ? "#" + pre.id + "-L" + a : "#" + pre.id + "-L" + a + "-L" + b;
+  }
+
+  // The block's active line selection from the URL hash as 1-based child
+  // indices `{a, b}` (a <= b, clamped to the block), or null when the hash does
+  // not target lines of this block.
+  function selectedRange(pre) {
+    const m = HASH_RE.exec(location.hash);
+    if (!(m && m[1] === pre.id && m[2])) return null;
+    const off = lnStart(pre) - 1;
+    const n = pre.querySelectorAll(".line").length;
+    const a = Math.max(Math.min(+m[2], m[3] ? +m[3] : +m[2]) - off, 1);
+    const b = Math.min(Math.max(+m[2], m[3] ? +m[3] : +m[2]) - off, n);
+    return a <= b ? { a: a, b: b } : null;
   }
 
   function onGutterMouseDown(e) {
@@ -252,6 +305,7 @@
     document.addEventListener("mousemove", onDragMove);
     document.addEventListener("mouseup", onDragEnd);
     document.addEventListener("click", onDocumentClick);
+    document.addEventListener("click", onCopyClick, true); // capture: beats copy.js
     applyHash(location.hash, true); // restore + scroll on load
     window.addEventListener("hashchange", function () {
       applyHash(location.hash, true);

--- a/docs/src/linenumbers.md
+++ b/docs/src/linenumbers.md
@@ -12,6 +12,9 @@ style. Try it on the block below:
 - click the **link button** (top right of the block) to **copy the link** —
   to the current line selection if you have one in that block, else to the
   whole block; the icon flashes a checkmark to confirm,
+- click the **copy button** next to it to **copy the code** — likewise just
+  the selected lines if you have a selection in that block, else the whole
+  block,
 - click anywhere outside the block to **deselect**.
 
 The selection is reflected in the URL fragment (`#c-1a2b3c4d-L3-L7`), so a

--- a/test/playwright/verify.js
+++ b/test/playwright/verify.js
@@ -277,14 +277,17 @@ function check(name, ok, detail) {
   }
 
   // A selection in ANOTHER block is not this block's: copy the whole block.
-  const elsewhere = await page.evaluate((id) => {
-    const p = Array.from(document.querySelectorAll("code.line-numbers")).find(
-      (c) => c.parentElement.id !== id && c.querySelectorAll(".line").length >= 2
-    );
-    p.parentElement.scrollIntoView({ block: "center" });
-    const r0 = p.querySelectorAll(".line-num")[0].getBoundingClientRect();
-    return { x: r0.left + r0.width / 2, y: r0.top + r0.height / 2 };
-  }, ID);
+  // (computed at use time: scrolling into view shifts the coordinates)
+  const elsewherePos = () =>
+    page.evaluate((id) => {
+      const p = Array.from(document.querySelectorAll("code.line-numbers")).find(
+        (c) => c.parentElement.id !== id && c.querySelectorAll(".line").length >= 2
+      );
+      p.parentElement.scrollIntoView({ block: "center" });
+      const r0 = p.querySelectorAll(".line-num")[0].getBoundingClientRect();
+      return { x: r0.left + r0.width / 2, y: r0.top + r0.height / 2 };
+    }, ID);
+  let elsewhere = await elsewherePos();
   await page.mouse.click(elsewhere.x, elsewhere.y); // select a line elsewhere
   await page.click("#" + ID + " .block-link");
   r = await state();
@@ -293,6 +296,79 @@ function check(name, ok, detail) {
     r.hash === "#" + ID,
     r.hash
   );
+  await reset();
+
+  // ---- Documenter's copy button copies just the selected lines (#26) ----
+  // Our capture-phase hook only kicks in with a selection in THIS block; the
+  // other cases must still go through Documenter's own handler (whole block).
+  const COPY = "#" + ID + " .copy-button";
+  const copyBtn = await page.evaluate((sel) => !!document.querySelector(sel), COPY);
+  check("Documenter copy button is present", copyBtn);
+  const blockText = await page.evaluate((id) => document.getElementById(id).innerText, ID);
+  const linesText = (a, b) =>
+    page.evaluate(
+      ([id, a, b]) =>
+        Array.from(document.getElementById(id).querySelectorAll(".line"))
+          .slice(a - 1, b)
+          .map((l) => l.textContent)
+          .join("\n"),
+      [ID, a, b]
+    );
+  const copyFeedback = () =>
+    page
+      .waitForSelector(COPY + ".success", { timeout: 2000 })
+      .then(() => true)
+      .catch(() => false);
+  const resetCopyBtn = () =>
+    page.evaluate((sel) => {
+      const b = document.querySelector(sel);
+      b.classList.add("fa-copy");
+      b.classList.remove("success", "fa-check", "error", "fa-xmark");
+    }, COPY);
+
+  // Lines 2-4 selected: copy button copies exactly those lines, keeps selection.
+  pos = await gutterPos(2);
+  await page.mouse.click(pos.x, pos.y);
+  pos = await gutterPos(4);
+  await page.keyboard.down("Shift");
+  await page.mouse.click(pos.x, pos.y);
+  await page.keyboard.up("Shift");
+  await page.hover("#" + ID);
+  await page.click(COPY);
+  check("copy with selection shows copied feedback", await copyFeedback());
+  r = await state();
+  check("copy keeps the line selection", r.hl === 3 && /-L2-L4$/.test(r.hash), r.hash);
+  clip = await readClipboard();
+  if (clip !== null) {
+    const expected = await linesText(2, 4);
+    check("clipboard holds only the selected lines", clip === expected, JSON.stringify(clip));
+  }
+  await resetCopyBtn();
+
+  // No selection: Documenter's own handler copies the whole block.
+  await reset();
+  await page.hover("#" + ID);
+  await page.click(COPY);
+  check("copy without selection shows copied feedback", await copyFeedback());
+  clip = await readClipboard();
+  if (clip !== null) {
+    check("clipboard holds the whole block", clip === blockText, JSON.stringify(clip));
+  }
+  await resetCopyBtn();
+
+  // Selection in ANOTHER block: this block still copies in full.
+  elsewhere = await elsewherePos();
+  await page.mouse.click(elsewhere.x, elsewhere.y);
+  r = await state();
+  check("selection elsewhere: set up", r.hl === 1 && !r.hash.startsWith("#" + ID), r.hash);
+  await page.hover("#" + ID);
+  await page.click(COPY);
+  check("selection elsewhere: copy shows copied feedback", await copyFeedback());
+  clip = await readClipboard();
+  if (clip !== null) {
+    check("selection elsewhere: clipboard holds the whole block", clip === blockText, JSON.stringify(clip));
+  }
+  await resetCopyBtn();
   await reset();
 
   // ---- hash restore on fresh load ----


### PR DESCRIPTION
Documenter's copy-code button next to the permalink button always copied
the whole block, even with lines selected in the gutter, while the
permalink button already targets the selection. Make them consistent.

Documenter's copy.js is left untouched: line-numbers.js registers a
capture-phase click listener on `document`, which runs before the
button's own listener regardless of script load order. When the
clicked button's block has a line selection (from the URL hash) the
handler stops propagation, copies just those lines (textContent of the
`.line` spans joined by "\n", the same shape as pre.innerText) and
replays copy.js's feedback classes (success/fa-check, error/fa-xmark,
reset after 5 s). Without a selection it returns early and Documenter's
handler copies the whole block exactly as before.

The hash->range math is factored into `selectedRange(pre)`, shared with
the permalink button, and the clipboard write is split out of the
permalink's `copyText` into `writeClipboard`.

The Ctrl+C suggestion from the issue is deliberately not implemented:
no comparable tool (GitHub etc.) copies gutter-selected lines on Ctrl+C
and it would conflict with native text selection.

Closes #26.
